### PR TITLE
Validate Withings weights as they come in

### DIFF
--- a/packages/bdt-customisations/.gitignore
+++ b/packages/bdt-customisations/.gitignore
@@ -30,3 +30,5 @@ vendor
 composer.lock
 composer.phar
 composer-setup.php
+
+.phpunit.result.cache

--- a/packages/bdt-customisations/README.md
+++ b/packages/bdt-customisations/README.md
@@ -44,4 +44,4 @@ composer update
 bash bin/install-wp-tests.sh wordpress_test root root localhost latest true
 ```
 
-After that you should have a working environment. Run `phpunit` and they should execute fine.
+After that you should have a working environment. Run `phpunit` to execute.

--- a/packages/bdt-customisations/README.md
+++ b/packages/bdt-customisations/README.md
@@ -34,3 +34,14 @@ An example film query might look like:
 ## Building
 
 To build, run `yarn build`. And then upload to WP blog manually.
+
+## PHPUnit Tests
+
+The lowest friction route to running the PHPUnit tests is in the [local by Flywheel](https://localwp.com/) shell. Go to the plugin folder in a test instance and run:
+
+```
+composer update
+bash bin/install-wp-tests.sh wordpress_test root root localhost latest true
+```
+
+After that you should have a working environment. Run `phpunit` and they should execute fine.

--- a/packages/bdt-customisations/bin/install-wp-tests.sh
+++ b/packages/bdt-customisations/bin/install-wp-tests.sh
@@ -19,7 +19,7 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
-        curl -s "$1" > "$2";
+        curl -sL "$1" > "$2";
     elif [ `which wget` ]; then
         wget -nv -O "$2" "$1"
     fi
@@ -107,8 +107,8 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		svn co --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/packages/bdt-customisations/composer.json
+++ b/packages/bdt-customisations/composer.json
@@ -1,6 +1,7 @@
 {
-    "require-dev": {
-        "yoast/phpunit-polyfills": "^1.0",
-        "wp-graphql/wp-graphql": "*"
-    }
+  "require-dev": {
+    "yoast/phpunit-polyfills": "^1.0",
+    "wp-graphql/wp-graphql": "*",
+    "dms/phpunit-arraysubset-asserts": "^0.5.0"
+  }
 }

--- a/packages/bdt-customisations/tests/bootstrap.php
+++ b/packages/bdt-customisations/tests/bootstrap.php
@@ -5,6 +5,7 @@
  * @package Bdt_Customisations
  */
 require_once 'vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+require_once 'vendor/dms/phpunit-arraysubset-asserts/assertarraysubset-autoload.php';
 
 $_tests_dir = getenv('WP_TESTS_DIR');
 

--- a/packages/bdt-customisations/tests/test-letterboxd-fetcher.php
+++ b/packages/bdt-customisations/tests/test-letterboxd-fetcher.php
@@ -1,6 +1,8 @@
 <?php
 namespace bdt;
 
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
+
 if (! class_exists('SimplePie', false)) {
     require_once ABSPATH . WPINC . '/class-simplepie.php';
 }
@@ -33,43 +35,43 @@ class LetterboxdFetcherTest extends \WP_UnitTestCase
     public function test_maps_to_correct_fields()
     {
         $film = get_updated_feeds()[0];
-        $this->assertArraySubset(array(
-                'filmTitle' => 'Nina Conti: Her Master\'s Voice',
-                'watchedDate' => '2020-12-24',
-                'rating' => '4.0',
-                'link' => 'https://letterboxd.com/simonscarfe/film/nina-conti-her-masters-voice/',
-                'filmYear' => '2012'
-            ), $film);
+        Assert::assertArraySubset(array(
+            'filmTitle' => 'Nina Conti: Her Master\'s Voice',
+            'watchedDate' => '2020-12-24',
+            'rating' => '4.0',
+            'link' => 'https://letterboxd.com/simonscarfe/film/nina-conti-her-masters-voice/',
+            'filmYear' => '2012'
+        ), $film);
     }
     
     public function test_pulls_in_image()
     {
         $film = get_updated_feeds()[0];
-        $this->assertArraySubset(array(
-                'image' => 'https://a.ltrbxd.com/resized/film-poster/7/9/8/4/5/79845-nina-conti-her-master-s-voice-0-500-0-750-crop.jpg?k=32fa68989e',
-            ), $film);
+        Assert::assertArraySubset(array(
+            'image' => 'https://a.ltrbxd.com/resized/film-poster/7/9/8/4/5/79845-nina-conti-her-master-s-voice-0-500-0-750-crop.jpg?k=32fa68989e',
+        ), $film);
     }
     
     public function test_pulls_in_review()
     {
         $film = get_updated_feeds()[1];
-        $this->assertArraySubset(array(
-                'review' => '<p>Lovely</p>',
-            ), $film);
+        Assert::assertArraySubset(array(
+            'review' => '<p>Lovely</p>',
+        ), $film);
     }
     
     public function test_preserves_formatting()
     {
         $film = get_updated_feeds()[2];
-        $this->assertArraySubset(array(
-                'review' => '<p>Separate</p><p>P</p><p>tags.</p>',
-            ), $film);
+        Assert::assertArraySubset(array(
+            'review' => '<p>Separate</p><p>P</p><p>tags.</p>',
+        ), $film);
     }
     
     public function test_ignores_non_reviews()
     {
         $film = get_updated_feeds()[0];
-        $this->assertArraySubset(array(
+        Assert::assertArraySubset(array(
             'review' => false,
         ), $film);
     }

--- a/packages/bdt-customisations/tests/test-weighins.php
+++ b/packages/bdt-customisations/tests/test-weighins.php
@@ -17,12 +17,6 @@ class Test_Weighin_Filter extends \WP_UnitTestCase
      */
     private $user_id;
 
-    /**
-     * Holds post id.
-     *
-     * @var int
-     */
-    private $post_id;
 
     /**
      * Create a user and a post for our test.
@@ -72,5 +66,25 @@ class Test_Weighin_Filter extends \WP_UnitTestCase
         $post = get_post($weighin_id);
 
         $this->assertEquals('bdt_weighin', $post->post_type);
+    }
+
+    public function test_weighin_filter_rejects_bad_data()
+    {
+        $request = new \WP_REST_Request('POST', '/wp/v2/bdt_weighin');
+        $request->set_body_params(
+            array(
+                "meta" => array(
+                    "weight" => "10"
+                ),
+                "status" => "publish"
+            )
+        );
+        $response = $this->server->dispatch($request);
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey('data', $data);
+        $this->assertIsArray($data['data']);
+        $this->assertArrayHasKey('status', $data['data']);
+        $this->assertEquals(400, $data['data']['status']);
     }
 }

--- a/packages/bdt-customisations/tests/test-weighins.php
+++ b/packages/bdt-customisations/tests/test-weighins.php
@@ -1,0 +1,76 @@
+<?php
+namespace bdt;
+
+class Test_Weighin_Filter extends \WP_UnitTestCase
+{
+    /**
+     * Holds the WP REST Server object
+     *
+     * @var WP_REST_Server
+     */
+    private $server;
+
+    /**
+     * Holds user id.
+     *
+     * @var int
+     */
+    private $user_id;
+
+    /**
+     * Holds post id.
+     *
+     * @var int
+     */
+    private $post_id;
+
+    /**
+     * Create a user and a post for our test.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Initiating the REST API.
+        global $wp_rest_server;
+        $this->server = $wp_rest_server = new \WP_REST_Server;
+        do_action('rest_api_init');
+
+        $this->user_id = wp_insert_user([
+            'user_login' => 'test_user',
+            'user_pass' => 'test_password',
+            'role' => 'administrator'
+        ]);
+        wp_set_current_user($this->user_id);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        wp_delete_user($this->user_id);
+    }
+
+
+    public function test_weighin_filter_lets_valid_post_through()
+    {
+        $request = new \WP_REST_Request('POST', '/wp/v2/bdt_weighin');
+        $request->set_body_params(
+            array(
+                "meta" => array(
+                    "weight" => "10",
+                    "weighin_time" => "November 30, 2024 at 05:49AM",
+                    "body_fat_percentage" => "2323"
+                ),
+                "status" => "publish"
+            )
+        );
+        $response = $this->server->dispatch($request);
+        $data = $response->get_data();
+
+        $weighin_id = $data['id'];
+        $post = get_post($weighin_id);
+
+        $this->assertEquals('bdt_weighin', $post->post_type);
+    }
+}


### PR DESCRIPTION
Closes #733 

Every now and then, Withings sends incomplete data. It populates WordPress with data that clashes with the GraphQL schema. And breaks my daily build.

This change applies a WordPress filter to the rest API call which checks all expected fields are there, rejecting with a 400 error if any are missing.