### PR TITLE
Add option for bodyfat percentage

### DIFF
--- a/packages/bdt-astro/public/style/global.scss
+++ b/packages/bdt-astro/public/style/global.scss
@@ -165,6 +165,23 @@ footer * {
   flex-grow: 1;
 }
 
+.line-selector-form {
+  display: flex;
+  align-items: center;
+}
+.line-selector-cb {
+  display: flex;
+  gap: 10px;
+  flex-grow: 1;
+  margin-bottom: var(--s-1);
+}
+
+.line-selector-cb label {
+  padding: var(--s-4);
+  width: var(--s3);
+  flex: 1;
+}
+
 .rdp {
   position: absolute;
   z-index: 1;

--- a/packages/bdt-components/src/visualisations/weight-graph.test.tsx
+++ b/packages/bdt-components/src/visualisations/weight-graph.test.tsx
@@ -79,6 +79,17 @@ describe("basic weight graph rendering", () => {
     expect(dots).toHaveLength(3);
   });
 
+  it("renders renders no dots if there are more than 31", () => {
+    const weighins = generateWeighins(32);
+
+    const { container } = render(
+      <WeightGraph weighins={weighins} responsive={false} />
+    );
+
+    const dots = getDots(container);
+    expect(dots).toHaveLength(0);
+  });
+
   it("filters using from", () => {
     const weighins = generateWeighins(3);
 

--- a/packages/bdt-components/src/visualisations/weight-graph.test.tsx
+++ b/packages/bdt-components/src/visualisations/weight-graph.test.tsx
@@ -233,7 +233,7 @@ describe("trend lines", () => {
   });
 });
 
-describe("weight navigation", () => {
+describe("date selector", () => {
   it("displays to and from fields", () => {
     const weighins = generateWeighins(10);
 
@@ -339,5 +339,78 @@ describe("weight navigation", () => {
     fireEvent.click(getByText("Change dates"));
 
     expect(getByText("January 2020")).toBeVisible();
+  });
+});
+
+describe("line picker", () => {
+  it("displays checkboxes for line controls", () => {
+    const weighins = generateWeighins(10);
+
+    const { getByLabelText } = render(
+      <WeightGraph weighins={weighins} responsive={false} />
+    );
+
+    expect(getByLabelText("Weight")).toBeVisible();
+    expect(getByLabelText("Weight Trend")).toBeVisible();
+    expect(getByLabelText("Bodyfat")).toBeVisible();
+  });
+
+  const hasLegendText = (container: HTMLElement, text: string) =>
+    [...container.querySelectorAll(".recharts-legend-item-text")].filter(
+      (i) => i.textContent === text
+    ).length > 0;
+
+  it("sets expected initial state", () => {
+    const weighins = generateWeighins(10);
+
+    const { getByLabelText, container } = render(
+      <WeightGraph weighins={weighins} responsive={false} />
+    );
+
+    expect(getByLabelText("Weight")).toBeChecked();
+    expect(getByLabelText("Weight Trend")).toBeChecked();
+    expect(getByLabelText("Bodyfat")).not.toBeChecked();
+
+    expect(
+      container.querySelectorAll(".recharts-line path.recharts-line-curve")
+    ).toHaveLength(2);
+
+    expect(hasLegendText(container, "weight")).toBeTruthy();
+    expect(hasLegendText(container, "weightTrend")).toBeTruthy();
+    expect(hasLegendText(container, "bodyFatPercentage")).toBeFalsy();
+  });
+
+  it("checking the bodyfat box shows the bfp line", () => {
+    const weighins = generateWeighins(10);
+
+    const { getByLabelText, container } = render(
+      <WeightGraph weighins={weighins} responsive={false} />
+    );
+
+    fireEvent.click(getByLabelText("Bodyfat"));
+
+    expect(
+      container.querySelectorAll(".recharts-line path.recharts-line-curve")
+    ).toHaveLength(3);
+
+    expect(hasLegendText(container, "bodyFatPercentage")).toBeTruthy();
+  });
+
+  it("unchecking the weight and trend boxes hides the respective lines", () => {
+    const weighins = generateWeighins(10);
+
+    const { getByLabelText, container } = render(
+      <WeightGraph weighins={weighins} responsive={false} />
+    );
+
+    fireEvent.click(getByLabelText("Weight"));
+    fireEvent.click(getByLabelText("Weight Trend"));
+
+    expect(
+      container.querySelectorAll(".recharts-line path.recharts-line-curve")
+    ).toHaveLength(0);
+
+    expect(hasLegendText(container, "weight")).toBeFalsy();
+    expect(hasLegendText(container, "weightTrend")).toBeFalsy();
   });
 });

--- a/packages/bdt-components/src/visualisations/weight-graph.tsx
+++ b/packages/bdt-components/src/visualisations/weight-graph.tsx
@@ -130,6 +130,14 @@ export default ({
               type="number"
               domain={["dataMin-0.1", "dataMax+0.1"]}
               tickFormatter={tickWeightFormatter}
+              yAxisId="weight"
+            />
+            <YAxis
+              type="number"
+              domain={["dataMin-0.1", "dataMax+0.1"]}
+              tickFormatter={tickWeightFormatter}
+              yAxisId="bfp"
+              orientation="right"
             />
             <Tooltip
               labelFormatter={(value) =>
@@ -137,13 +145,14 @@ export default ({
               }
             />
             <Legend />
-            <Line
+            {/* <Line
               type="monotone"
               dataKey="weight"
               stroke="#b81007"
               activeDot={{ r: 8 }}
               strokeWidth={2}
               isAnimationActive={responsive}
+              yAxisId="weight"
             />
             <Line
               type="monotone"
@@ -154,6 +163,18 @@ export default ({
               strokeDasharray="12 4"
               dot={{ strokeDasharray: "" }}
               isAnimationActive={responsive}
+              yAxisId="weight"
+            /> */}
+            <Line
+              type="monotone"
+              dataKey="bodyFatPercentage"
+              stroke="#050704"
+              activeDot={{ r: 8 }}
+              strokeWidth={2}
+              // strokeDasharray="12 4"
+              dot={{ strokeDasharray: "" }}
+              isAnimationActive={responsive}
+              yAxisId="bfp"
             />
           </LineChart>
         </ResponsiveContainer>

--- a/packages/bdt-components/src/visualisations/weight-graph.tsx
+++ b/packages/bdt-components/src/visualisations/weight-graph.tsx
@@ -34,8 +34,19 @@ export default ({
     to: filter?.to ? new Date(filter?.to) : undefined,
   };
 
+  type Filters = {
+    weight: boolean;
+    weightTrend: boolean;
+    bodyFatPercentage: boolean;
+  };
+
   const [range, setRange] = useState<DateRange | undefined>(defaultSelected);
   const [showDatePicker, setShowDatePicker] = useState<Boolean>(false);
+  const [filters, setFilters] = useState<Filters>({
+    weight: true,
+    weightTrend: true,
+    bodyFatPercentage: false,
+  });
 
   const filterDates = (
     weighins: Weighin[] | CalculatedWeighin[]
@@ -107,6 +118,53 @@ export default ({
           )}
         </div>
       </form>
+      <form className="line-selector-form">
+        <div className="line-selector-cb">
+          <input
+            type="checkbox"
+            name="show-weight"
+            id="show-weight"
+            checked={filters.weight}
+            onChange={() =>
+              setFilters({
+                ...filters,
+                weight: !filters.weight,
+              })
+            }
+          />
+          <label htmlFor="show-weight">Weight</label>
+        </div>
+        <div className="line-selector-cb">
+          <input
+            type="checkbox"
+            name="show-weight-trend"
+            id="show-weight-trend"
+            checked={filters.weightTrend}
+            onChange={() =>
+              setFilters({
+                ...filters,
+                weightTrend: !filters.weightTrend,
+              })
+            }
+          />
+          <label htmlFor="show-weight-trend">Weight Trend</label>
+        </div>
+        <div className="line-selector-cb">
+          <input
+            type="checkbox"
+            name="show-bfp"
+            id="show-bfp"
+            checked={filters.bodyFatPercentage}
+            onChange={() =>
+              setFilters({
+                ...filters,
+                bodyFatPercentage: !filters.bodyFatPercentage,
+              })
+            }
+          />
+          <label htmlFor="show-bfp">Bodyfat</label>
+        </div>
+      </form>
       <div>
         <ResponsiveContainer
           minWidth={200}
@@ -145,37 +203,43 @@ export default ({
               }
             />
             <Legend />
-            {/* <Line
-              type="monotone"
-              dataKey="weight"
-              stroke="#b81007"
-              activeDot={{ r: 8 }}
-              strokeWidth={2}
-              isAnimationActive={responsive}
-              yAxisId="weight"
-            />
-            <Line
-              type="monotone"
-              dataKey="weightTrend"
-              stroke="#345693"
-              activeDot={{ r: 8 }}
-              strokeWidth={2}
-              strokeDasharray="12 4"
-              dot={{ strokeDasharray: "" }}
-              isAnimationActive={responsive}
-              yAxisId="weight"
-            /> */}
-            <Line
-              type="monotone"
-              dataKey="bodyFatPercentage"
-              stroke="#050704"
-              activeDot={{ r: 8 }}
-              strokeWidth={2}
-              // strokeDasharray="12 4"
-              dot={{ strokeDasharray: "" }}
-              isAnimationActive={responsive}
-              yAxisId="bfp"
-            />
+            {filters.weight && (
+              <Line
+                type="monotone"
+                dataKey="weight"
+                stroke="#b81007"
+                activeDot={{ r: 8 }}
+                strokeWidth={2}
+                isAnimationActive={responsive}
+                yAxisId="weight"
+              />
+            )}
+            {filters.weightTrend && (
+              <Line
+                type="monotone"
+                dataKey="weightTrend"
+                stroke="#345693"
+                activeDot={{ r: 8 }}
+                strokeWidth={2}
+                strokeDasharray="12 4"
+                dot={{ strokeDasharray: "" }}
+                isAnimationActive={responsive}
+                yAxisId="weight"
+              />
+            )}
+            {filters.bodyFatPercentage && (
+              <Line
+                type="monotone"
+                dataKey="bodyFatPercentage"
+                stroke="#dfcc4c"
+                activeDot={{ r: 8 }}
+                strokeWidth={2}
+                dot={{ strokeDasharray: "" }}
+                isAnimationActive={responsive}
+                yAxisId="bfp"
+                data-testId="bfp-line"
+              />
+            )}
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/packages/bdt-components/src/visualisations/weight-graph.tsx
+++ b/packages/bdt-components/src/visualisations/weight-graph.tsx
@@ -212,6 +212,7 @@ export default ({
                 strokeWidth={2}
                 isAnimationActive={responsive}
                 yAxisId="weight"
+                dot={formatted.length <= 31}
               />
             )}
             {filters.weightTrend && (
@@ -222,7 +223,7 @@ export default ({
                 activeDot={{ r: 8 }}
                 strokeWidth={2}
                 strokeDasharray="12 4"
-                dot={{ strokeDasharray: "" }}
+                dot={formatted.length <= 31 ? { strokeDasharray: "" } : false}
                 isAnimationActive={responsive}
                 yAxisId="weight"
               />
@@ -234,7 +235,7 @@ export default ({
                 stroke="#dfcc4c"
                 activeDot={{ r: 8 }}
                 strokeWidth={2}
-                dot={{ strokeDasharray: "" }}
+                dot={formatted.length <= 31}
                 isAnimationActive={responsive}
                 yAxisId="bfp"
                 data-testId="bfp-line"

--- a/packages/bdt-components/tsconfig.json
+++ b/packages/bdt-components/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/esm",
     "module": "es2015",
-    "target": "es5",
+    "target": "es2015",
     "lib": ["es6", "dom", "es2016", "es2017"],
     "jsx": "react-jsx",
     "declaration": true,


### PR DESCRIPTION
<img width="685" alt="image" src="https://github.com/SimonS/tdee-plaything/assets/1513/2406eddb-0b54-459a-a7a6-02977cf7afb5">

Added a new bodyfat line to the weight graph (the data was already there. It's ugly and grossly inaccessible, mostly because I've tied it to the current palette (a redesign is underway), but functionally it works.

With the extra noisiness, I turned it off by default, but also added some simple checkbox filters to toggle each of the respective lines. Also, with respect to visual noise, I noticed that when you expand to a large date range, it becomes hard to parse. So any time there is more than a month of weigh ins to display, I hide the dots.

My god though, is it ugly.