### PR TITLE
Strava fetch activity

### DIFF
--- a/packages/bdt-cdk/lambda/strava-processor/index.ts
+++ b/packages/bdt-cdk/lambda/strava-processor/index.ts
@@ -44,7 +44,9 @@ export const handler = async (event: SQSEvent): Promise<void> => {
           `Ignoring message for object_type ${object_type}, aspect_type ${aspect_type}`
         );
       }
-    } catch (error) {}
+    } catch (error) {
+      console.error(`Error processing SQS message ${record.messageId}:`, error);
+    }
   }
 
   console.log("Processing complete.");

--- a/packages/bdt-cdk/lambda/strava-processor/index.ts
+++ b/packages/bdt-cdk/lambda/strava-processor/index.ts
@@ -1,8 +1,5 @@
 import { SQSEvent, SQSRecord } from "aws-lambda";
-import {
-  SSMClient,
-  GetParametersCommand,
-} from "@aws-sdk/client-ssm";
+import { SSMClient, GetParametersCommand } from "@aws-sdk/client-ssm";
 
 import axios from "axios";
 
@@ -17,9 +14,9 @@ interface StravaCredentials {
 export const handler = async (event: SQSEvent): Promise<void> => {
   console.log(`Processor Lambda invoked with ${event.Records.length} record.`);
 
-  let access_token: string;
+  let accessToken: string;
   try {
-    access_token = await getStravaAccessToken();
+    accessToken = await getStravaAccessToken();
     console.log("Access token refreshed.");
   } catch (error) {
     console.error("Error refreshing access token:", error);
@@ -29,6 +26,25 @@ export const handler = async (event: SQSEvent): Promise<void> => {
   for (const record of event.Records) {
     console.log("Processing SQS message:", record.messageId);
     console.log("Body:", record.body);
+
+    try {
+      const messageData = JSON.parse(record.body);
+      const { object_type, object_id, aspect_type } = messageData;
+
+      if (
+        object_type === "activity" &&
+        (aspect_type === "create" || aspect_type === "update")
+      ) {
+        console.log(`Processing activity ${object_id} (${aspect_type})`);
+
+        const data = await getStravaActivity(accessToken, object_id);
+        console.log("Fetched Strava activity data:", data);
+      } else {
+        console.log(
+          `Ignoring message for object_type ${object_type}, aspect_type ${aspect_type}`
+        );
+      }
+    } catch (error) {}
   }
 
   console.log("Processing complete.");
@@ -87,7 +103,7 @@ async function getStravaCredentials(): Promise<StravaCredentials> {
     Names: ssmParameterNames,
     WithDecryption: true,
   });
-  
+
   const { Parameters: params, InvalidParameters } =
     await ssmClient.send(command);
   if (InvalidParameters && InvalidParameters.length > 0) {
@@ -110,4 +126,24 @@ async function getStravaCredentials(): Promise<StravaCredentials> {
   }
   console.log("Successfully fetched Strava credentials from SSM.");
   return credentials;
+}
+
+async function getStravaActivity(
+  accessToken: string,
+  activityId: string
+): Promise<any> {
+  const activityUrl = `https://www.strava.com/api/v3/activities/${activityId}`;
+  try {
+    const response = await axios.get(activityUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    console.log("Fetched Strava activity data:", response.data);
+    return response.data;
+  } catch (apiError: any) {
+    console.error(
+      `Error fetching activity ${activityId} from Strava:`,
+      apiError.response?.data || apiError.message
+    );
+    throw apiError;
+  }
 }

--- a/packages/bdt-cdk/lambda/strava-processor/index.ts
+++ b/packages/bdt-cdk/lambda/strava-processor/index.ts
@@ -1,7 +1,30 @@
 import { SQSEvent, SQSRecord } from "aws-lambda";
+import {
+  SSMClient,
+  GetParametersCommand,
+} from "@aws-sdk/client-ssm";
+
+import axios from "axios";
+
+const ssmClient = new SSMClient({});
+
+interface StravaCredentials {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}
 
 export const handler = async (event: SQSEvent): Promise<void> => {
   console.log(`Processor Lambda invoked with ${event.Records.length} record.`);
+
+  let access_token: string;
+  try {
+    access_token = await getStravaAccessToken();
+    console.log("Access token refreshed.");
+  } catch (error) {
+    console.error("Error refreshing access token:", error);
+    throw error;
+  }
 
   for (const record of event.Records) {
     console.log("Processing SQS message:", record.messageId);
@@ -10,3 +33,81 @@ export const handler = async (event: SQSEvent): Promise<void> => {
 
   console.log("Processing complete.");
 };
+
+async function getStravaAccessToken(): Promise<string> {
+  const credentials = await getStravaCredentials();
+
+  const tokenUrl = "https://www.strava.com/oauth/token";
+  const params = new URLSearchParams();
+  params.append("client_id", credentials.clientId);
+  params.append("client_secret", credentials.clientSecret);
+  params.append("refresh_token", credentials.refreshToken);
+  params.append("grant_type", "refresh_token");
+
+  try {
+    console.log("Requesting new Strava access token...");
+
+    const response = await axios.post(tokenUrl, params, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    if (response.data?.access_token) {
+      console.log("Successfully obtained new access token.");
+      return response.data.access_token;
+    } else {
+      throw new Error("Access token not found in Strava response.");
+    }
+  } catch (error: any) {
+    console.error(
+      "Error refreshing Strava token:",
+      error.response?.data || error.message
+    );
+    throw new Error("Failed to refresh Strava access token.");
+  }
+}
+
+async function getStravaCredentials(): Promise<StravaCredentials> {
+  const clientIdParam = process.env.STRAVA_CLIENT_ID_PARAM_NAME;
+  const clientSecretParam = process.env.STRAVA_SECRET_PARAM_NAME;
+  const refreshTokenParam = process.env.STRAVA_REFRESH_TOKEN_PARAM_NAME;
+
+  if (!clientIdParam || !clientSecretParam || !refreshTokenParam) {
+    console.error(
+      "FATAL: Missing required SSM parameter name environment variables (STRAVA_CLIENT_ID_PARAM_NAME, STRAVA_SECRET_PARAM_NAME, STRAVA_REFRESH_TOKEN_PARAM_NAME)."
+    );
+    throw new Error("Missing Strava credential configuration.");
+  }
+
+  const ssmParameterNames = [
+    clientIdParam,
+    clientSecretParam,
+    refreshTokenParam,
+  ];
+  const command = new GetParametersCommand({
+    Names: ssmParameterNames,
+    WithDecryption: true,
+  });
+  
+  const { Parameters: params, InvalidParameters } =
+    await ssmClient.send(command);
+  if (InvalidParameters && InvalidParameters.length > 0) {
+    throw new Error(`Invalid parameters: ${InvalidParameters.join(", ")}`);
+  }
+  if (!params || params.length !== 3) {
+    throw new Error("Failed to retrieve all params.");
+  }
+  const credentials = {
+    clientId: params.find((p) => p.Name === clientIdParam)?.Value!,
+    clientSecret: params.find((p) => p.Name === clientSecretParam)?.Value!,
+    refreshToken: params.find((p) => p.Name === refreshTokenParam)?.Value!,
+  };
+  if (
+    !credentials.clientId ||
+    !credentials.clientSecret ||
+    !credentials.refreshToken
+  ) {
+    throw new Error("Failed to retrieve all credential values.");
+  }
+  console.log("Successfully fetched Strava credentials from SSM.");
+  return credentials;
+}

--- a/packages/bdt-cdk/lambda/strava-receiver/index.ts
+++ b/packages/bdt-cdk/lambda/strava-receiver/index.ts
@@ -25,19 +25,12 @@ export const handler = async (
     const expectedVerifyToken = process.env.STRAVA_VERIFY_TOKEN;
 
     if (verifyToken === expectedVerifyToken) {
-      return {
-        statusCode: 200,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ "hub.challenge": challenge }),
-      };
+      return respondWith(200, JSON.stringify({ "hub.challenge": challenge }));
     } else {
       console.error(
         "Strava webhook verification failed. Invalid verify token."
       );
-      return {
-        statusCode: 403,
-        body: "Forbidden",
-      };
+      return respondWith(403, "Forbidden");
     }
   } else if (httpMethod === "POST") {
     const queueUrl = process.env.QUEUE_URL;
@@ -46,11 +39,17 @@ export const handler = async (
       console.error(
         "Configuration Error: QUEUE_URL environment variable not set."
       );
-      return {
-        statusCode: 500,
-        body: "Internal configuration error.",
-      };
+      return respondWith(500, "Internal configuration error");
     }
+
+    let parsedBody;
+    try {
+      parsedBody = JSON.parse(event.body ? event.body : "");
+    } catch (error) {
+      console.error("Error parsing JSON body:", error);
+      return respondWith(400, "Invalid JSON body.");
+    }
+    console.log("Successfully parsed body:", parsedBody);
 
     try {
       const messageBody =
@@ -66,24 +65,18 @@ export const handler = async (
       });
 
       const sqsResult = await sqsClient.send(command);
-      console.log("Successfully sent message to SQS:", sqsResult.MessageId);
 
-      return {
-        statusCode: 200,
-        body: "Message received and queued.",
-      };
+      console.log("Successfully sent message to SQS:", sqsResult.MessageId);
+      return respondWith(200, "Message received and queued.");
     } catch (error) {
       console.error("Error sending message to SQS:", error);
-
-      return {
-        statusCode: 500,
-        body: "Failed to queue message.",
-      };
+      return respondWith(500, "Failed to queue message.");
     }
   }
 
-  return {
-    statusCode: 405,
-    body: "Method Not Allowed",
-  };
+  return respondWith(405, "Method Not Allowed");
+};
+
+const respondWith = (statusCode: number, body: string) => {
+  return { statusCode, body, headers: { "Content-Type": "application/json" } };
 };

--- a/packages/bdt-cdk/lambda/strava-receiver/index.ts
+++ b/packages/bdt-cdk/lambda/strava-receiver/index.ts
@@ -67,11 +67,13 @@ const receiveEvent = async (event: APIGatewayProxyEventV2) => {
 
   const { object_type, object_id, aspect_type, owner_id } = parsedBody || {};
 
-  if (object_type !== 'activity') {
-    console.log(`Ignoring non-activity event: ${object_type}`);
-    return respondWith(200, 'Event received but not processed (non-activity).');
-}
-  
+  if ((aspect_type !== "create" && aspect_type !== "update") || object_type !== "activity") {
+    console.log(
+      `Ignoring event: ${object_type} / ${aspect_type}`
+    );
+    return respondWith(200, "Event received but not processed (delete/other).");
+  }
+
   type StravaEvent = {
     object_type: string;
     object_id: string;

--- a/packages/bdt-cdk/lambda/strava-receiver/index.ts
+++ b/packages/bdt-cdk/lambda/strava-receiver/index.ts
@@ -15,7 +15,7 @@ export const handler = async (
 
   if (httpMethod === "GET") {
     return verifySubscription(event);
-  } 
+  }
   if (httpMethod === "POST") {
     return receiveEvent(event);
   }
@@ -41,60 +41,63 @@ const verifySubscription = (event: APIGatewayProxyEventV2) => {
   if (verifyToken === expectedVerifyToken) {
     return respondWith(200, JSON.stringify({ "hub.challenge": challenge }));
   } else {
-    console.error(
-      "Strava webhook verification failed. Invalid verify token."
-    );
+    console.error("Strava webhook verification failed. Invalid verify token.");
     return respondWith(403, "Forbidden");
   }
-}
+};
 
 const receiveEvent = async (event: APIGatewayProxyEventV2) => {
   const queueUrl = process.env.QUEUE_URL;
 
-    if (!queueUrl) {
-      console.error(
-        "Configuration Error: QUEUE_URL environment variable not set."
-      );
-      return respondWith(500, "Internal configuration error");
-    }
+  if (!queueUrl) {
+    console.error(
+      "Configuration Error: QUEUE_URL environment variable not set."
+    );
+    return respondWith(500, "Internal configuration error");
+  }
 
-    let parsedBody;
-    try {
-      parsedBody = JSON.parse(event.body ? event.body : "");
-    } catch (error) {
-      console.error("Error parsing JSON body:", error);
-      return respondWith(400, "Invalid JSON body.");
-    }
-    console.log("Successfully parsed body:", parsedBody);
+  let parsedBody;
+  try {
+    parsedBody = JSON.parse(event.body ? event.body : "");
+  } catch (error) {
+    console.error("Error parsing JSON body:", error);
+    return respondWith(400, "Invalid JSON body.");
+  }
+  console.log("Successfully parsed body:", parsedBody);
 
-    const { object_type, object_id, aspect_type, owner_id } = parsedBody || {};
+  const { object_type, object_id, aspect_type, owner_id } = parsedBody || {};
 
-    type StravaEvent = {
-      object_type: string;
-      object_id: string;
-      aspect_type: string;
-      owner_id: string;
-    };
-    
-    const messageForQueue: StravaEvent = {
-      object_type,
-      object_id,
-      aspect_type,
-      owner_id,
-    };
-
-    try {
-      const command = new SendMessageCommand({
-        QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(messageForQueue),
-      });
-
-      const sqsResult = await sqsClient.send(command);
-
-      console.log("Successfully sent message to SQS:", sqsResult.MessageId);
-      return respondWith(200, "Message received and queued.");
-    } catch (error) {
-      console.error("Error sending message to SQS:", error);
-      return respondWith(500, "Failed to queue message.");
-    }
+  if (object_type !== 'activity') {
+    console.log(`Ignoring non-activity event: ${object_type}`);
+    return respondWith(200, 'Event received but not processed (non-activity).');
 }
+  
+  type StravaEvent = {
+    object_type: string;
+    object_id: string;
+    aspect_type: string;
+    owner_id: string;
+  };
+
+  const messageForQueue: StravaEvent = {
+    object_type,
+    object_id,
+    aspect_type,
+    owner_id,
+  };
+
+  try {
+    const command = new SendMessageCommand({
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(messageForQueue),
+    });
+
+    const sqsResult = await sqsClient.send(command);
+
+    console.log("Successfully sent message to SQS:", sqsResult.MessageId);
+    return respondWith(200, "Message received and queued.");
+  } catch (error) {
+    console.error("Error sending message to SQS:", error);
+    return respondWith(500, "Failed to queue message.");
+  }
+};

--- a/packages/bdt-cdk/lambda/strava-receiver/index.ts
+++ b/packages/bdt-cdk/lambda/strava-receiver/index.ts
@@ -14,26 +14,42 @@ export const handler = async (
   const httpMethod = event.requestContext.http.method;
 
   if (httpMethod === "GET") {
-    console.log(
-      "Strava webhook verification successful. Responding with challenge."
+    return verifySubscription(event);
+  } 
+  if (httpMethod === "POST") {
+    return receiveEvent(event);
+  }
+
+  return respondWith(405, "Method Not Allowed");
+};
+
+const respondWith = (statusCode: number, body: string) => {
+  return { statusCode, body, headers: { "Content-Type": "application/json" } };
+};
+
+const verifySubscription = (event: APIGatewayProxyEventV2) => {
+  console.log(
+    "Strava webhook verification successful. Responding with challenge."
+  );
+
+  const queryParams = event.queryStringParameters || {};
+  const challenge = queryParams["hub.challenge"];
+  const verifyToken = queryParams["hub.verify_token"];
+
+  const expectedVerifyToken = process.env.STRAVA_VERIFY_TOKEN;
+
+  if (verifyToken === expectedVerifyToken) {
+    return respondWith(200, JSON.stringify({ "hub.challenge": challenge }));
+  } else {
+    console.error(
+      "Strava webhook verification failed. Invalid verify token."
     );
+    return respondWith(403, "Forbidden");
+  }
+}
 
-    const queryParams = event.queryStringParameters || {};
-    const challenge = queryParams["hub.challenge"];
-    const verifyToken = queryParams["hub.verify_token"];
-
-    const expectedVerifyToken = process.env.STRAVA_VERIFY_TOKEN;
-
-    if (verifyToken === expectedVerifyToken) {
-      return respondWith(200, JSON.stringify({ "hub.challenge": challenge }));
-    } else {
-      console.error(
-        "Strava webhook verification failed. Invalid verify token."
-      );
-      return respondWith(403, "Forbidden");
-    }
-  } else if (httpMethod === "POST") {
-    const queueUrl = process.env.QUEUE_URL;
+const receiveEvent = async (event: APIGatewayProxyEventV2) => {
+  const queueUrl = process.env.QUEUE_URL;
 
     if (!queueUrl) {
       console.error(
@@ -51,17 +67,26 @@ export const handler = async (
     }
     console.log("Successfully parsed body:", parsedBody);
 
-    try {
-      const messageBody =
-        event.body ??
-        JSON.stringify({
-          warning: "Received event with no body",
-          receivedAt: new Date().toISOString(),
-        });
+    const { object_type, object_id, aspect_type, owner_id } = parsedBody || {};
 
+    type StravaEvent = {
+      object_type: string;
+      object_id: string;
+      aspect_type: string;
+      owner_id: string;
+    };
+    
+    const messageForQueue: StravaEvent = {
+      object_type,
+      object_id,
+      aspect_type,
+      owner_id,
+    };
+
+    try {
       const command = new SendMessageCommand({
         QueueUrl: queueUrl,
-        MessageBody: messageBody,
+        MessageBody: JSON.stringify(messageForQueue),
       });
 
       const sqsResult = await sqsClient.send(command);
@@ -72,11 +97,4 @@ export const handler = async (
       console.error("Error sending message to SQS:", error);
       return respondWith(500, "Failed to queue message.");
     }
-  }
-
-  return respondWith(405, "Method Not Allowed");
-};
-
-const respondWith = (statusCode: number, body: string) => {
-  return { statusCode, body, headers: { "Content-Type": "application/json" } };
-};
+}

--- a/packages/bdt-cdk/lib/bdt-cdk-stack.ts
+++ b/packages/bdt-cdk/lib/bdt-cdk-stack.ts
@@ -4,11 +4,11 @@ import { Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { HttpApi, HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
 import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
-import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { Queue } from "aws-cdk-lib/aws-sqs";
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import path = require("path");
-
 
 export class BdtCdkStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
@@ -39,7 +39,7 @@ export class BdtCdkStack extends Stack {
     const webhookQueue = new Queue(this, "StravaWebhookQueue", {
       queueName: "strava-webhook-queue",
     });
-    
+
     const receiverLambda = new NodejsFunction(
       this,
       "StravaWebhookReceiverLambda",
@@ -68,13 +68,47 @@ export class BdtCdkStack extends Stack {
       integration: stravaWebhookIntegration,
     });
 
-    const processorLambda = new NodejsFunction(this, 'StravaEventProcessorLambda', {
-      entry: path.join(__dirname, '../lambda/strava-processor/index.ts'),
-      functionName: 'stravaEventProcessorLambda',
-      runtime: Runtime.NODEJS_22_X,
-      handler: 'index.handler',
-    });
+    const processorLambda = new NodejsFunction(
+      this,
+      "StravaEventProcessorLambda",
+      {
+        entry: path.join(__dirname, "../lambda/strava-processor/index.ts"),
+        functionName: "stravaEventProcessorLambda",
+        runtime: Runtime.NODEJS_22_X,
+        handler: "index.handler",
+      }
+    );
 
     processorLambda.addEventSource(new SqsEventSource(webhookQueue));
+
+    const clientIdParamName = "/strava/client_id";
+    const clientSecretParamName = "/strava/client_secret";
+    const refreshTokenParamName = "/strava/refresh_token";
+
+    const clientIdParamArn = `arn:${this.partition}:ssm:${this.region}:${this.account}:parameter${clientIdParamName}`;
+    const clientSecretParamArn = `arn:${this.partition}:ssm:${this.region}:${this.account}:parameter${clientSecretParamName}`;
+    const refreshTokenParamArn = `arn:${this.partition}:ssm:${this.region}:${this.account}:parameter${refreshTokenParamName}`;
+
+    processorLambda.addToRolePolicy(
+      new PolicyStatement({
+        sid: "ReadStravaSSMParams",
+        effect: Effect.ALLOW,
+        actions: ["ssm:GetParameter", "ssm:GetParameters"],
+        resources: [
+          clientIdParamArn,
+          clientSecretParamArn,
+          refreshTokenParamArn,
+        ],
+      })
+    );
+
+    processorLambda.addToRolePolicy(
+      new PolicyStatement({
+        sid: "DecryptStravaSecureParams",
+        effect: Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+      })
+    );
   }
 }

--- a/packages/bdt-cdk/lib/bdt-cdk-stack.ts
+++ b/packages/bdt-cdk/lib/bdt-cdk-stack.ts
@@ -76,6 +76,11 @@ export class BdtCdkStack extends Stack {
         functionName: "stravaEventProcessorLambda",
         runtime: Runtime.NODEJS_22_X,
         handler: "index.handler",
+        environment: {
+          STRAVA_CLIENT_ID_PARAM_NAME: "/strava/client_id",
+          STRAVA_SECRET_PARAM_NAME: "/strava/client_secret",
+          STRAVA_REFRESH_TOKEN_PARAM_NAME: "/strava/refresh_token",
+        },
       }
     );
 

--- a/packages/bdt-cdk/package.json
+++ b/packages/bdt-cdk/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.787.0",
+    "@aws-sdk/client-ssm": "^3.799.0",
     "@tdee/overcast-functions": "*",
     "axios": "^1.8.4"
   },

--- a/packages/bdt-cdk/test/bdt-cdk.test.ts
+++ b/packages/bdt-cdk/test/bdt-cdk.test.ts
@@ -187,3 +187,16 @@ test("Processor Lambda Role should have permissions to read Strava creds from SS
     },
   });
 });
+
+test("Processor Lambda use environment variables for SSM parameter names", () => {
+  template.hasResourceProperties("AWS::Lambda::Function", {
+    FunctionName: "stravaEventProcessorLambda",
+    Environment: Match.objectLike({
+      Variables: Match.objectLike({
+        STRAVA_CLIENT_ID_PARAM_NAME: "/strava/client_id",
+        STRAVA_SECRET_PARAM_NAME: "/strava/client_secret",
+        STRAVA_REFRESH_TOKEN_PARAM_NAME: "/strava/refresh_token",
+      }),
+    }),
+  });
+});

--- a/packages/bdt-cdk/test/bdt-cdk.test.ts
+++ b/packages/bdt-cdk/test/bdt-cdk.test.ts
@@ -5,6 +5,7 @@ import * as BdtCdk from "../lib/bdt-cdk-stack";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 
 let template: Template;
+let stack: BdtCdk.BdtCdkStack;
 
 beforeAll(() => {
   const app = new cdk.App({
@@ -12,7 +13,7 @@ beforeAll(() => {
       "aws:cdk:bundling-stacks": [],
     },
   });
-  const stack = new BdtCdk.BdtCdkStack(app, "TestStack");
+  stack = new BdtCdk.BdtCdkStack(app, "TestStack");
   template = Template.fromStack(stack);
 });
 
@@ -163,5 +164,26 @@ test("Receiver Lambda Role should have SendMessage permission for Webhook Queue"
         Ref: Match.stringLikeRegexp("StravaWebhookReceiverLambdaServiceRole*"),
       },
     ]),
+  });
+});
+
+test("Processor Lambda Role should have permissions to read Strava creds from SSM", () => {
+  template.hasResourceProperties("AWS::IAM::Policy", {
+    Roles: Match.arrayWith([
+      { Ref: Match.stringLikeRegexp("StravaEventProcessorLambdaServiceRole*") },
+    ]),
+    PolicyDocument: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Effect: "Allow",
+          Action: Match.arrayWith(["ssm:GetParameter", "ssm:GetParameters"]),
+        }),
+        Match.objectLike({
+          Effect: "Allow",
+          Action: "kms:Decrypt",
+          Resource: "*",
+        }),
+      ]),
+    },
   });
 });

--- a/packages/bdt-cdk/test/strava-processor.test.ts
+++ b/packages/bdt-cdk/test/strava-processor.test.ts
@@ -2,6 +2,85 @@ import { expect, test, afterEach, jest, afterAll } from "@jest/globals";
 
 import { handler } from "../lambda/strava-processor/index";
 import { SQSEvent, SQSRecord } from "aws-lambda";
+import {
+  SSMClient,
+  GetParametersCommand,
+  Parameter,
+} from "@aws-sdk/client-ssm";
+
+import axios from "axios";
+import { mockClient } from "aws-sdk-client-mock";
+import "aws-sdk-client-mock-jest";
+import { beforeEach } from "node:test";
+
+jest.mock("axios", () => {
+  const mockPost = jest.fn();
+  return {
+    __esModule: true,
+
+    default: { post: mockPost },
+    post: mockPost,
+  };
+});
+const mockedAxiosPost = axios.post as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const dummyCredentials = {
+  clientId: "TEST_CLIENT_ID",
+  clientSecret: "TEST_CLIENT_SECRET",
+  refreshToken: "TEST_REFRESH_TOKEN",
+};
+
+const mockStravaAuth = () => {
+  const paramNames = {
+    clientId: "/strava/client_id",
+    clientSecret: "/strava/client_secret",
+    refreshToken: "/strava/refresh_token",
+  };
+  
+  process.env.STRAVA_CLIENT_ID_PARAM_NAME = paramNames.clientId;
+  process.env.STRAVA_SECRET_PARAM_NAME = paramNames.clientSecret;
+  process.env.STRAVA_REFRESH_TOKEN_PARAM_NAME = paramNames.refreshToken;
+  
+  const dummyAccessToken = "DUMMY_ACCESS_TOKEN_456";
+
+  mockedAxiosPost.mockImplementation(async () => {
+    return Promise.resolve({
+      data: { access_token: dummyAccessToken },
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      config: {} as any,
+    });
+  });
+
+  const ssmMock = mockClient(SSMClient);
+  ssmMock.on(GetParametersCommand).resolves({
+    Parameters: [
+      {
+        Name: paramNames.clientId,
+        Value: dummyCredentials.clientId,
+        Type: "String",
+      },
+      {
+        Name: paramNames.clientSecret,
+        Value: dummyCredentials.clientSecret,
+        Type: "SecureString",
+      },
+      {
+        Name: paramNames.refreshToken,
+        Value: dummyCredentials.refreshToken,
+        Type: "SecureString",
+      },
+    ] as Parameter[],
+    InvalidParameters: [],
+  });
+};
+
+mockStravaAuth();
 
 const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
 
@@ -40,7 +119,32 @@ test("log the body of each received SQS message", async () => {
   expect(consoleLogSpy).toHaveBeenCalledWith("Body:", testBody1);
   expect(consoleLogSpy).toHaveBeenCalledWith("Body:", testBody2);
 
-  expect(consoleLogSpy).toHaveBeenCalledWith('Processing SQS message:', expect.any(String));
+  expect(consoleLogSpy).toHaveBeenCalledWith(
+    "Processing SQS message:",
+    expect.any(String)
+  );
   expect(consoleLogSpy).toHaveBeenCalledWith("Processing complete.");
+});
 
+test("Processor Lambda attempts Strava token refresh using credentials from SSM", async () => {
+  const mockEvent = createPartialSqsEventWithBodies([
+    '{"message":"trigger auth"}',
+  ]);
+
+  await handler(mockEvent as SQSEvent);
+
+  const expectedTokenUrl = "https://www.strava.com/oauth/token";
+  const expectedFormData = new URLSearchParams();
+  expectedFormData.append("client_id", dummyCredentials.clientId);
+  expectedFormData.append("client_secret", dummyCredentials.clientSecret);
+  expectedFormData.append("refresh_token", dummyCredentials.refreshToken);
+  expectedFormData.append("grant_type", "refresh_token");
+
+  expect(mockedAxiosPost).toHaveBeenCalledWith(
+    expectedTokenUrl,
+    expectedFormData,
+    expect.objectContaining({
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    })
+  );
 });

--- a/packages/bdt-cdk/test/strava-processor.test.ts
+++ b/packages/bdt-cdk/test/strava-processor.test.ts
@@ -12,17 +12,21 @@ import axios from "axios";
 import { mockClient } from "aws-sdk-client-mock";
 import "aws-sdk-client-mock-jest";
 import { beforeEach } from "node:test";
+import { get } from "http";
 
 jest.mock("axios", () => {
   const mockPost = jest.fn();
+  const mockGet = jest.fn();
   return {
     __esModule: true,
 
-    default: { post: mockPost },
+    default: { post: mockPost, get: mockGet },
     post: mockPost,
+    get: mockGet,
   };
 });
 const mockedAxiosPost = axios.post as jest.Mock;
+const mockedAxiosGet = axios.get as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -40,11 +44,11 @@ const mockStravaAuth = () => {
     clientSecret: "/strava/client_secret",
     refreshToken: "/strava/refresh_token",
   };
-  
+
   process.env.STRAVA_CLIENT_ID_PARAM_NAME = paramNames.clientId;
   process.env.STRAVA_SECRET_PARAM_NAME = paramNames.clientSecret;
   process.env.STRAVA_REFRESH_TOKEN_PARAM_NAME = paramNames.refreshToken;
-  
+
   const dummyAccessToken = "DUMMY_ACCESS_TOKEN_456";
 
   mockedAxiosPost.mockImplementation(async () => {
@@ -147,4 +151,42 @@ test("Processor Lambda attempts Strava token refresh using credentials from SSM"
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
     })
   );
+});
+
+test("fetches activity details from Strava API", async () => {
+  const activityId = 9876543210;
+  const dummyActivityData = {
+    id: activityId,
+    name: "Test Activity for Logging",
+    distance: 1609,
+    moving_time: 300,
+    type: "Run",
+    start_date_local: new Date().toISOString(),
+  };
+
+  mockedAxiosGet.mockImplementation(async (url, config) => {
+    console.log(`--- MOCK GET returning data for ${url} ---`);
+    return Promise.resolve({
+      data: dummyActivityData,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {},
+    });
+  });
+
+  const sqsMessageBody = JSON.stringify({
+    object_type: "activity",
+    object_id: activityId,
+    aspect_type: "update",
+    owner_id: 12345
+  });
+  const mockEvent = createPartialSqsEventWithBodies([sqsMessageBody]);
+
+  await handler(mockEvent as SQSEvent);
+
+  expect(consoleLogSpy).toHaveBeenCalledWith("Fetched Strava activity data:", dummyActivityData);
+
+  expect(consoleLogSpy).toHaveBeenCalledWith("Processing complete.");
+
 });

--- a/packages/bdt-cdk/test/strava-processor.test.ts
+++ b/packages/bdt-cdk/test/strava-processor.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, afterEach, jest, afterAll } from "@jest/globals";
+import { expect, test, afterEach, jest, afterAll, beforeEach } from "@jest/globals";
 
 import { handler } from "../lambda/strava-processor/index";
 import { SQSEvent, SQSRecord } from "aws-lambda";
@@ -11,8 +11,6 @@ import {
 import axios from "axios";
 import { mockClient } from "aws-sdk-client-mock";
 import "aws-sdk-client-mock-jest";
-import { beforeEach } from "node:test";
-import { get } from "http";
 
 jest.mock("axios", () => {
   const mockPost = jest.fn();

--- a/packages/bdt-cdk/test/strava-receiver.test.ts
+++ b/packages/bdt-cdk/test/strava-receiver.test.ts
@@ -76,9 +76,19 @@ test("should parse webhook, extract IDs, and send structured message to SQS", as
 });
 
 test("return 200 OK but NOT queue message for non-activity events", async () => {
-  process.env.QUEUE_URL = "https://some-queue-url";
   const athleteEventPayload = makeStravaEvent("update", "athlete");
   const mockEvent = createMockApiGatewayEvent(athleteEventPayload);
+
+  const result = await handler(mockEvent as APIGatewayProxyEventV2);
+
+  expect(result.statusCode).toBe(200);
+  expect(result.body).toContain("Event received but not processed");
+  expect(sqsMock.calls()).toHaveLength(0);
+});
+
+test("return 200 OK but NOT queue message for deletes", async () => {
+  const deleteEvent = makeStravaEvent("delete");
+  const mockEvent = createMockApiGatewayEvent(deleteEvent);
 
   const result = await handler(mockEvent as APIGatewayProxyEventV2);
 

--- a/packages/bdt-cdk/test/strava-receiver.test.ts
+++ b/packages/bdt-cdk/test/strava-receiver.test.ts
@@ -49,9 +49,20 @@ test("return 500 error if QUEUE_URL environment variable is not set", async () =
   expect(result.body).toContain("Internal configuration error");
 });
 
-test("attempt to send event body to SQS queue specified by env var", async () => {
-  const testBody = { webhook_id: 123, data: "some Strava data" };
-  const mockEvent = createMockApiGatewayEvent(testBody);
+test("should parse webhook, extract IDs, and send structured message to SQS", async () => {
+  const stravaEventPayload = {
+    aspect_type: "update",
+    event_time: Date.now() / 1000,
+    object_id: 1234567890,
+    object_type: "activity",
+    owner_id: 987654,
+    subscription_id: 281030,
+    updates: { title: "New Test Title" },
+  };
+
+  const mockEvent = createMockApiGatewayEvent(
+    JSON.stringify(stravaEventPayload)
+  );
   sqsMock.on(SendMessageCommand).resolves({
     $metadata: { httpStatusCode: 200 },
     MessageId: "mock-message-id-abc-123",
@@ -62,9 +73,15 @@ test("attempt to send event body to SQS queue specified by env var", async () =>
   expect(result.statusCode).toBe(200);
   expect(result.body).toBe("Message received and queued.");
   expect(sqsMock.calls()).toHaveLength(1);
+
   expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
     QueueUrl: testQueueUrl,
-    MessageBody: JSON.stringify(testBody),
+    MessageBody: JSON.stringify({
+      object_type: stravaEventPayload.object_type,
+      object_id: stravaEventPayload.object_id,
+      aspect_type: stravaEventPayload.aspect_type,
+      owner_id: stravaEventPayload.owner_id,
+    }),
   });
 });
 
@@ -130,20 +147,19 @@ test("invalid verification GET request should return hub.challenge", async () =>
   };
 
   const result = await handler(mockEvent as APIGatewayProxyEventV2);
-  expect(result.body).toBe(JSON.stringify({ 'hub.challenge': challenge }));
-  expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
+  expect(result.body).toBe(JSON.stringify({ "hub.challenge": challenge }));
+  expect(result.headers).toEqual({ "Content-Type": "application/json" });
 });
 
-test('should return 400 Bad Request if POST body is not valid JSON', async () => {
+test("should return 400 Bad Request if POST body is not valid JSON", async () => {
   const invalidJsonBody = "{ not valid json '";
-  const mockEvent = createMockApiGatewayEvent(invalidJsonBody, 'POST');
+  const mockEvent = createMockApiGatewayEvent(invalidJsonBody, "POST");
 
   const result = await handler(mockEvent as APIGatewayProxyEventV2);
 
   expect(result.statusCode).toBe(400);
   expect(sqsMock.calls()).toHaveLength(0);
 });
-
 
 function createMockApiGatewayEvent(
   eventBody: any,

--- a/packages/bdt-cdk/test/strava-receiver.test.ts
+++ b/packages/bdt-cdk/test/strava-receiver.test.ts
@@ -134,6 +134,17 @@ test("invalid verification GET request should return hub.challenge", async () =>
   expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
 });
 
+test('should return 400 Bad Request if POST body is not valid JSON', async () => {
+  const invalidJsonBody = "{ not valid json '";
+  const mockEvent = createMockApiGatewayEvent(invalidJsonBody, 'POST');
+
+  const result = await handler(mockEvent as APIGatewayProxyEventV2);
+
+  expect(result.statusCode).toBe(400);
+  expect(sqsMock.calls()).toHaveLength(0);
+});
+
+
 function createMockApiGatewayEvent(
   eventBody: any,
   method: string = "POST"
@@ -145,6 +156,6 @@ function createMockApiGatewayEvent(
         path: "/strava/webhook",
       },
     } as any,
-    body: JSON.stringify(eventBody),
+    body: typeof eventBody === "string" ? eventBody : JSON.stringify(eventBody),
   };
 }

--- a/packages/bdt-cdk/test/strava-receiver.test.ts
+++ b/packages/bdt-cdk/test/strava-receiver.test.ts
@@ -50,19 +50,9 @@ test("return 500 error if QUEUE_URL environment variable is not set", async () =
 });
 
 test("should parse webhook, extract IDs, and send structured message to SQS", async () => {
-  const stravaEventPayload = {
-    aspect_type: "update",
-    event_time: Date.now() / 1000,
-    object_id: 1234567890,
-    object_type: "activity",
-    owner_id: 987654,
-    subscription_id: 281030,
-    updates: { title: "New Test Title" },
-  };
+  const stravaEventPayload = makeStravaEvent();
 
-  const mockEvent = createMockApiGatewayEvent(
-    JSON.stringify(stravaEventPayload)
-  );
+  const mockEvent = createMockApiGatewayEvent(stravaEventPayload);
   sqsMock.on(SendMessageCommand).resolves({
     $metadata: { httpStatusCode: 200 },
     MessageId: "mock-message-id-abc-123",
@@ -85,10 +75,21 @@ test("should parse webhook, extract IDs, and send structured message to SQS", as
   });
 });
 
+test("return 200 OK but NOT queue message for non-activity events", async () => {
+  process.env.QUEUE_URL = "https://some-queue-url";
+  const athleteEventPayload = makeStravaEvent("update", "athlete");
+  const mockEvent = createMockApiGatewayEvent(athleteEventPayload);
+
+  const result = await handler(mockEvent as APIGatewayProxyEventV2);
+
+  expect(result.statusCode).toBe(200);
+  expect(result.body).toContain("Event received but not processed");
+  expect(sqsMock.calls()).toHaveLength(0);
+});
+
 test("returns 500 error if SQS send fails", async () => {
-  const mockEvent = createMockApiGatewayEvent({
-    message: "trigger SQS failure",
-  });
+  const straveEventPayload = makeStravaEvent("update");
+  const mockEvent = createMockApiGatewayEvent(straveEventPayload);
 
   const sqsError = new Error("AWS SQS simulated error");
   sqsMock.on(SendMessageCommand).rejects(sqsError);
@@ -173,5 +174,17 @@ function createMockApiGatewayEvent(
       },
     } as any,
     body: typeof eventBody === "string" ? eventBody : JSON.stringify(eventBody),
+  };
+}
+
+function makeStravaEvent(aspect_type: string = "update", object_type: string = "activity") {
+  return {
+    aspect_type,
+    event_time: Date.now() / 1000,
+    object_id: 1234567890,
+    object_type,
+    owner_id: 987654,
+    subscription_id: 281030,
+    updates: { title: "New Test Title" },
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,54 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-ssm@^3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-ssm/-/client-ssm-3.799.0.tgz#5511d15c660128a48e7250cc90ad1265f83f76a0"
+  integrity sha512-8f3wnHy9ieSSfHkvMhI5EP/JJBREFYu6AJipyhD6UFd202SgnL83r+BrMy9Bux09lCRux0ZlPalgXlMRGIXb/w==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/credential-provider-node" "3.799.0"
+    "@aws-sdk/middleware-host-header" "3.775.0"
+    "@aws-sdk/middleware-logger" "3.775.0"
+    "@aws-sdk/middleware-recursion-detection" "3.775.0"
+    "@aws-sdk/middleware-user-agent" "3.799.0"
+    "@aws-sdk/region-config-resolver" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.787.0"
+    "@aws-sdk/util-user-agent-browser" "3.775.0"
+    "@aws-sdk/util-user-agent-node" "3.799.0"
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/core" "^3.3.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.1"
+    "@smithy/middleware-retry" "^4.1.1"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.9"
+    "@smithy/util-defaults-mode-node" "^4.0.9"
+    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    "@smithy/util-utf8" "^4.0.0"
+    "@smithy/util-waiter" "^4.0.3"
+    "@types/uuid" "^9.0.1"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
 "@aws-sdk/client-sso@3.787.0":
   version "3.787.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.787.0.tgz#39f1182296b586cb957b449b5f0dabd8f378cf1a"
@@ -228,6 +276,50 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-sso@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.799.0.tgz#4e1e0831100a93147e9cfb8b29bcee88344effa0"
+  integrity sha512-/i/LG7AiWPmPxKCA2jnR2zaf7B3HYSTbxaZI21ElIz9wASlNAsKr8CnLY7qb50kOyXiNfQ834S5Q3Gl8dX9o3Q==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/middleware-host-header" "3.775.0"
+    "@aws-sdk/middleware-logger" "3.775.0"
+    "@aws-sdk/middleware-recursion-detection" "3.775.0"
+    "@aws-sdk/middleware-user-agent" "3.799.0"
+    "@aws-sdk/region-config-resolver" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.787.0"
+    "@aws-sdk/util-user-agent-browser" "3.775.0"
+    "@aws-sdk/util-user-agent-node" "3.799.0"
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/core" "^3.3.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.1"
+    "@smithy/middleware-retry" "^4.1.1"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.9"
+    "@smithy/util-defaults-mode-node" "^4.0.9"
+    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/core@3.775.0":
   version "3.775.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.775.0.tgz#5d22ba78f07c07b48fb4d5b18172b9a896c0cbd0"
@@ -245,12 +337,40 @@
     fast-xml-parser "4.4.1"
     tslib "^2.6.2"
 
+"@aws-sdk/core@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.799.0.tgz#383f903ede137df108dcd5f817074515d2b1242e"
+  integrity sha512-hkKF3Zpc6+H8GI1rlttYVRh9uEE77cqAzLmLpY3iu7sql8cZgPERRBfaFct8p1SaDyrksLNiboD1vKW58mbsYg==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/core" "^3.3.0"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/signature-v4" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-middleware" "^4.0.2"
+    fast-xml-parser "4.4.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-env@3.775.0":
   version "3.775.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz#b8c81818f4c62d89b5f04dc410ab9b48e954f22c"
   integrity sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==
   dependencies:
     "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.799.0.tgz#d933265b54b18ef1232762c318ff0d75bc7785f9"
+  integrity sha512-vT/SSWtbUIOW/U21qgEySmmO44SFWIA7WeQPX1OrI8WJ5n7OEI23JWLHjLvHTkYmuZK6z1rPcv7HzRgmuGRibA==
+  dependencies:
+    "@aws-sdk/core" "3.799.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
@@ -272,6 +392,22 @@
     "@smithy/util-stream" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-http@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.799.0.tgz#9286235bb30c4f22fbeac0ecf2fe5e5f99aaa282"
+  integrity sha512-2CjBpOWmhaPAExOgHnIB5nOkS5ef+mfRlJ1JC4nsnjAx0nrK4tk0XRE0LYz11P3+ue+a86cU8WTmBo+qjnGxPQ==
+  dependencies:
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-stream" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-ini@3.787.0":
   version "3.787.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.787.0.tgz#906ece004141462ae695504b6c07d1200688fd6c"
@@ -284,6 +420,25 @@
     "@aws-sdk/credential-provider-sso" "3.787.0"
     "@aws-sdk/credential-provider-web-identity" "3.787.0"
     "@aws-sdk/nested-clients" "3.787.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.799.0.tgz#89ed328e40d2bf0c37453c26b1dd74201c61da2c"
+  integrity sha512-M9ubILFxerqw4QJwk83MnjtZyoA2eNCiea5V+PzZeHlwk2PON/EnawKqy65x9/hMHGoSvvNuby7iMAmPptu7yw==
+  dependencies:
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/credential-provider-env" "3.799.0"
+    "@aws-sdk/credential-provider-http" "3.799.0"
+    "@aws-sdk/credential-provider-process" "3.799.0"
+    "@aws-sdk/credential-provider-sso" "3.799.0"
+    "@aws-sdk/credential-provider-web-identity" "3.799.0"
+    "@aws-sdk/nested-clients" "3.799.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/credential-provider-imds" "^4.0.2"
     "@smithy/property-provider" "^4.0.2"
@@ -309,12 +464,42 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.799.0.tgz#45e646a24f105782dbaf3c55951dbae32ae73074"
+  integrity sha512-nd9fSJc0wUlgKUkIr2ldJhcIIrzJFS29AGZoyY22J3xih63nNDv61eTGVMsDZzHlV21XzMlPEljTR7axiimckg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.799.0"
+    "@aws-sdk/credential-provider-http" "3.799.0"
+    "@aws-sdk/credential-provider-ini" "3.799.0"
+    "@aws-sdk/credential-provider-process" "3.799.0"
+    "@aws-sdk/credential-provider-sso" "3.799.0"
+    "@aws-sdk/credential-provider-web-identity" "3.799.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@3.775.0":
   version "3.775.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz#7ab90383f12461c5d20546e933924e654660542b"
   integrity sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==
   dependencies:
     "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.799.0.tgz#34e8b3d7c889bbb87dfe7c171255a8b99a34df25"
+  integrity sha512-g8jmNs2k98WNHMYcea1YKA+7ao2Ma4w0P42Dz4YpcI155pQHxHx25RwbOG+rsAKuo3bKwkW53HVE/ZTKhcWFgw==
+  dependencies:
+    "@aws-sdk/core" "3.799.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
@@ -335,6 +520,20 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-sso@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.799.0.tgz#535dd1d1abe5f2567551514444f18b79993ac92e"
+  integrity sha512-lQv27QkNU9FJFZqEf5DIEN3uXEN409Iaym9WJzhOouGtxvTIAWiD23OYh1u8PvBdrordJGS2YddfQvhcmq9akw==
+  dependencies:
+    "@aws-sdk/client-sso" "3.799.0"
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/token-providers" "3.799.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-web-identity@3.787.0":
   version "3.787.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.787.0.tgz#d492d1f4a90b70f3a71a65f11b8d3ef79fb2759e"
@@ -342,6 +541,18 @@
   dependencies:
     "@aws-sdk/core" "3.775.0"
     "@aws-sdk/nested-clients" "3.787.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.799.0.tgz#ddf6c4e6f692289ba9e5db3ba9c63564742e5533"
+  integrity sha512-8k1i9ut+BEg0QZ+I6UQMxGNR1T8paLmAOAZXU+nLQR0lcxS6lr8v+dqofgzQPuHLBkWNCr1Av1IKeL3bJjgU7g==
+  dependencies:
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/nested-clients" "3.799.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
@@ -401,6 +612,19 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-user-agent@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.799.0.tgz#e120e6e1341bcba5427cee0385172170e4615186"
+  integrity sha512-TropQZanbOTxa+p+Nl4fWkzlRhgFwDfW+Wb6TR3jZN7IXHNlPpgGFpdrgvBExhW/RBhqr+94OsR8Ou58lp3hhA==
+  dependencies:
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.787.0"
+    "@smithy/core" "^3.3.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/nested-clients@3.787.0":
   version "3.787.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.787.0.tgz#e8a5a6e7d0b599a7f9f15b900d3223ad080b0a81"
@@ -445,6 +669,50 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/nested-clients@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.799.0.tgz#a3b223cfa22f809cee28eedea2ce1f30175665f9"
+  integrity sha512-zILlWh7asrcQG9JYMYgnvEQBfwmWKfED0yWCf3UNAmQcfS9wkCAWCgicNy/y5KvNvEYnHidsU117STtyuUNG5g==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.799.0"
+    "@aws-sdk/middleware-host-header" "3.775.0"
+    "@aws-sdk/middleware-logger" "3.775.0"
+    "@aws-sdk/middleware-recursion-detection" "3.775.0"
+    "@aws-sdk/middleware-user-agent" "3.799.0"
+    "@aws-sdk/region-config-resolver" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.787.0"
+    "@aws-sdk/util-user-agent-browser" "3.775.0"
+    "@aws-sdk/util-user-agent-node" "3.799.0"
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/core" "^3.3.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.1"
+    "@smithy/middleware-retry" "^4.1.1"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.9"
+    "@smithy/util-defaults-mode-node" "^4.0.9"
+    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/region-config-resolver@3.775.0":
   version "3.775.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz#592b52498e68501fe46480be3dfb185e949d1eab"
@@ -463,6 +731,18 @@
   integrity sha512-d7/NIqxq308Zg0RPMNrmn0QvzniL4Hx8Qdwzr6YZWLYAbUSvZYS2ppLR3BFWSkV6SsTJUx8BuDaj3P8vttkrog==
   dependencies:
     "@aws-sdk/nested-clients" "3.787.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.799.0.tgz#7b2cc6aa5b1a1058490b780ff975de29218ef3a0"
+  integrity sha512-/8iDjnsJs/D8AhGbDAmdF5oSHzE4jsDsM2RIIxmBAKTZXkaaclQBNX9CmAqLKQmO3IUMZsDH2KENHLVAk/N/mw==
+  dependencies:
+    "@aws-sdk/nested-clients" "3.799.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
@@ -510,6 +790,17 @@
   integrity sha512-mG7Lz8ydfG4SF9e8WSXiPQ/Lsn3n8A5B5jtPROidafi06I3ckV2WxyMLdwG14m919NoS6IOfWHyRGSqWIwbVKA==
   dependencies:
     "@aws-sdk/middleware-user-agent" "3.787.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@3.799.0":
+  version "3.799.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.799.0.tgz#8d0794add4efc79830143277f5faa27f16531c7a"
+  integrity sha512-iXBk38RbIWPF5Nq9O4AnktORAzXovSVqWYClvS1qbE7ILsnTLJbagU9HlU25O2iV5COVh1qZkwuP5NHQ2yTEyw==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "3.799.0"
     "@aws-sdk/types" "3.775.0"
     "@smithy/node-config-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
@@ -2835,6 +3126,20 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@smithy/core@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.3.0.tgz#a6b141733fa530cb2f9b49a8e70ae98169c92cf0"
+  integrity sha512-r6gvs5OfRq/w+9unPm7B3po4rmWaGh0CIL/OwHntGGux7+RhOOZLGuurbeMgWV6W55ZuyMTypJLeH0vn/ZRaWQ==
+  dependencies:
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-stream" "^4.2.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@smithy/credential-provider-imds@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz#1ec34a04842fa69996b151a695b027f0486c69a8"
@@ -2921,6 +3226,20 @@
     "@smithy/util-middleware" "^4.0.2"
     tslib "^2.6.2"
 
+"@smithy/middleware-endpoint@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.1.tgz#d210cac102a645ea35541c17fda52c73f0b56304"
+  integrity sha512-z5RmcHxjvScL+LwEDU2mTNCOhgUs4lu5PGdF1K36IPRmUHhNFxNxgenSB7smyDiYD4vdKQ7CAZtG5cUErqib9w==
+  dependencies:
+    "@smithy/core" "^3.3.0"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
 "@smithy/middleware-retry@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz#338ac1e025bbc6fd7b008152c4efa8bc0591acc9"
@@ -2933,6 +3252,21 @@
     "@smithy/types" "^4.2.0"
     "@smithy/util-middleware" "^4.0.2"
     "@smithy/util-retry" "^4.0.2"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
+"@smithy/middleware-retry@^4.1.1":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.2.tgz#ea421e56d596d9e7af9fbbfd1a39acdbaf9ab8e9"
+  integrity sha512-qN/Mmxm8JWtFAjozJ8VSTM83KOX4cIks8UjDqqNkKIegzPrE5ZKPNCQ/DqUSIF90pue5a/NycNXnBod2NwvZZQ==
+  dependencies:
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/service-error-classification" "^4.0.3"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.3"
     tslib "^2.6.2"
     uuid "^9.0.1"
 
@@ -3013,6 +3347,13 @@
   dependencies:
     "@smithy/types" "^4.2.0"
 
+"@smithy/service-error-classification@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.0.3.tgz#df43e3ec00a9f2d15415185561d98cd602c8bc67"
+  integrity sha512-FTbcajmltovWMjj3tksDQdD23b2w6gH+A0DYA1Yz3iSpjDj8fmkwy62UnXcWMy4d5YoMoSyLFHMfkEVEzbiN8Q==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+
 "@smithy/shared-ini-file-loader@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz#15043f0516fe09ff4b22982bc5f644dc701ebae5"
@@ -3021,7 +3362,7 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/signature-v4@^5.0.2":
+"@smithy/signature-v4@^5.0.2", "@smithy/signature-v4@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.1.0.tgz#2c56e5b278482b04383d84ea2c07b7f0a8eb8f63"
   integrity sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==
@@ -3042,6 +3383,19 @@
   dependencies:
     "@smithy/core" "^3.2.0"
     "@smithy/middleware-endpoint" "^4.1.0"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-stream" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.2.1.tgz#21055bc038824de93aee778d040cdf9864e6114d"
+  integrity sha512-fbniZef60QdsBc4ZY0iyI8xbFHIiC/QRtPi66iE4ufjiE/aaz7AfUXzcWMkpO8r+QhLeNRIfmPchIG+3/QDZ6g==
+  dependencies:
+    "@smithy/core" "^3.3.0"
+    "@smithy/middleware-endpoint" "^4.1.1"
     "@smithy/middleware-stack" "^4.0.2"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
@@ -3121,6 +3475,17 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
+"@smithy/util-defaults-mode-browser@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.9.tgz#b70915229126eee4c1df18cd8f1e8edabade9c41"
+  integrity sha512-B8j0XsElvyhv6+5hlFf6vFV/uCSyLKcInpeXOGnOImX2mGXshE01RvPoGipTlRpIk53e6UfYj7WdDdgbVfXDZw==
+  dependencies:
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.1"
+    "@smithy/types" "^4.2.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@smithy/util-defaults-mode-node@^4.0.8":
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz#123b517efe6434977139b341d1f64b5f1e743aac"
@@ -3131,6 +3496,19 @@
     "@smithy/node-config-provider" "^4.0.2"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.9.tgz#2d50bcb178a214878a86563616a0b3499550a9d2"
+  integrity sha512-wTDU8P/zdIf9DOpV5qm64HVgGRXvqjqB/fJZTEQbrz3s79JHM/E7XkMm/876Oq+ZLHJQgnXM9QHDo29dlM62eA==
+  dependencies:
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.1"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
@@ -3164,6 +3542,15 @@
   integrity sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==
   dependencies:
     "@smithy/service-error-classification" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.0.3.tgz#42d54b3a100915b61c6f9bee43c966e96139584d"
+  integrity sha512-DPuYjZQDXmKr/sNvy9Spu8R/ESa2e22wXZzSAY6NkjOLj6spbIje/Aq8rT97iUMdDj0qHMRIe+bTxvlU74d9Ng==
+  dependencies:
+    "@smithy/service-error-classification" "^4.0.3"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
@@ -3202,6 +3589,15 @@
   integrity sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==
   dependencies:
     "@smithy/util-buffer-from" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-waiter@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-waiter/-/util-waiter-4.0.3.tgz#ec5605ec123493259ccbf1c0b5c1951b3360f43b"
+  integrity sha512-JtaY3FxmD+te+KSI2FJuEcfNC9T/DGGVf551babM7fAaXhjJUt7oSYurH1Devxd2+BOSUACCgt3buinx4UnmEA==
+  dependencies:
+    "@smithy/abort-controller" "^4.0.2"
+    "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
 "@storybook/addon-actions@^8.6.7":


### PR DESCRIPTION
Another part of #854 - this time we listen for new Strava events (specifically creates and updates), download the source activity and log it to the console. Now we just need to model said activity in WordPress, and we own our data. Fun.