### PR TITLE
feat(strava): post activities to WordPress as bdt_exercise posts (#854)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/lint-on-edit.sh"
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && .claude/hooks/lint-on-edit.sh"
           }
         ]
       },
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/mutation-reminder.sh"
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && .claude/hooks/mutation-reminder.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ pnpm --filter @tdee/bdt-cdk test
 
 # Run a single test file with root Jest
 pnpm jest -- packages/film-fetcher/src/getFilms.test.ts
+
+# CDK (aws-cdk CLI is a devDependency of bdt-cdk, use pnpm exec to invoke it)
+pnpm --filter @tdee/bdt-cdk exec cdk synth
+pnpm --filter @tdee/bdt-cdk exec cdk deploy
 ```
 
 Note: the root Jest config excludes `bdt-components` and `bdt-cdk` (they have their own test setups), so `pnpm test` runs root Jest first, then those two packages separately.

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ I try to build using decent (not best) practices - testing, not storing credenti
 * TypeScript - the predominant language I use.
 * Wordpress - the main intermediary store for most of this data. [bdt-customisations](https://github.com/SimonS/tdee-plaything/tree/master/packages/bdt-customisations) is where the tweaks I've made live.
 * GraphQL - the main method of exposing wordpress data to the outside world.
-* AWS CDK - for orchestrating quick/dirty serverless functions.
+* AWS CDK - for orchestrating quick/dirty serverless functions. The CDK CLI is a devDependency of `bdt-cdk`; run it via `pnpm --filter @tdee/bdt-cdk exec cdk <command>` (e.g. `synth`, `deploy`).
 * AstroJS - powerful little static site generator to publish the main website.

--- a/packages/bdt-cdk/jest.config.js
+++ b/packages/bdt-cdk/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   testEnvironment: "node",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   roots: ["<rootDir>/test"],
   testMatch: ["**/*.test.ts"],
   transform: {

--- a/packages/bdt-cdk/lambda/strava-processor/index.ts
+++ b/packages/bdt-cdk/lambda/strava-processor/index.ts
@@ -11,6 +11,80 @@ interface StravaCredentials {
   refreshToken: string;
 }
 
+export interface StravaActivity {
+  id: number;
+  name: string;
+  description?: string;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  total_elevation_gain: number;
+  type: string;
+  sport_type?: string;
+  start_date: string;
+  start_date_local: string;
+  map?: { summary_polyline?: string };
+}
+
+interface WordPressExerciseMeta {
+  source_platform: string;
+  source_id: string;
+  activity_type: string;
+  distance_meters: number;
+  moving_time_seconds: number;
+  elapsed_time_seconds: number;
+  total_elevation_gain_meters: number;
+  start_date_local_iso: string;
+  map_summary_polyline: string;
+  _raw_data_json: string;
+}
+
+export interface WordPressExercisePayload {
+  title: string;
+  content: string;
+  status: "publish";
+  meta: WordPressExerciseMeta;
+}
+
+export function stravaToWordpress(
+  activity: StravaActivity,
+): WordPressExercisePayload {
+  return {
+    title: activity.name || `Strava Activity ${activity.id}`,
+    content: activity.description ?? "",
+    status: "publish",
+    meta: {
+      source_platform: "strava",
+      source_id: String(activity.id),
+      activity_type: activity.type,
+      distance_meters: activity.distance,
+      moving_time_seconds: activity.moving_time,
+      elapsed_time_seconds: activity.elapsed_time,
+      total_elevation_gain_meters: activity.total_elevation_gain,
+      start_date_local_iso: activity.start_date_local,
+      map_summary_polyline: activity.map?.summary_polyline ?? "",
+      _raw_data_json: JSON.stringify(activity),
+    },
+  };
+}
+
+export async function postExerciseToWordpress(
+  payload: WordPressExercisePayload,
+): Promise<void> {
+  const authToken = process.env.BDT_AUTH_TOKEN;
+  const apiBaseUrl = process.env.WORDPRESS_API_BASE_URL;
+  if (!authToken || !apiBaseUrl) {
+    throw new Error("Missing WordPress configuration.");
+  }
+  await axios.post(`${apiBaseUrl}/bdt_exercises`, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+  console.log("Exercise posted to WordPress successfully.");
+}
+
 export const handler = async (event: SQSEvent): Promise<void> => {
   console.log(`Processor Lambda invoked with ${event.Records.length} record.`);
 
@@ -38,7 +112,8 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         console.log(`Processing activity ${object_id} (${aspect_type})`);
 
         const data = await getStravaActivity(accessToken, object_id);
-        console.log("Fetched Strava activity data:", data);
+        const wpPayload = stravaToWordpress(data);
+        await postExerciseToWordpress(wpPayload);
       } else {
         console.log(
           `Ignoring message for object_type ${object_type}, aspect_type ${aspect_type}`,
@@ -134,10 +209,10 @@ async function getStravaCredentials(): Promise<StravaCredentials> {
 async function getStravaActivity(
   accessToken: string,
   activityId: string,
-): Promise<unknown> {
+): Promise<StravaActivity> {
   const activityUrl = `https://www.strava.com/api/v3/activities/${activityId}`;
   try {
-    const response = await axios.get(activityUrl, {
+    const response = await axios.get<StravaActivity>(activityUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     console.log("Fetched Strava activity data:", response.data);

--- a/packages/bdt-cdk/lib/bdt-cdk-stack.ts
+++ b/packages/bdt-cdk/lib/bdt-cdk-stack.ts
@@ -80,6 +80,9 @@ export class BdtCdkStack extends Stack {
           STRAVA_CLIENT_ID_PARAM_NAME: "/strava/client_id",
           STRAVA_SECRET_PARAM_NAME: "/strava/client_secret",
           STRAVA_REFRESH_TOKEN_PARAM_NAME: "/strava/refresh_token",
+          BDT_AUTH_TOKEN: "",
+          WORDPRESS_API_BASE_URL:
+            "https://breakfastdinnertea.co.uk/wp-json/wp/v2",
         },
       },
     );

--- a/packages/bdt-cdk/package.json
+++ b/packages/bdt-cdk/package.json
@@ -22,6 +22,7 @@
     "@types/aws-lambda": "^8.10.161",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.15",
+    "aws-cdk": "^2.1118.0",
     "aws-cdk-lib": "^2.244.0",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-jest": "^4.1.0",

--- a/packages/bdt-cdk/test/bdt-cdk.test.ts
+++ b/packages/bdt-cdk/test/bdt-cdk.test.ts
@@ -200,3 +200,15 @@ test("Processor Lambda use environment variables for SSM parameter names", () =>
     }),
   });
 });
+
+test("Processor Lambda has WordPress env vars configured", () => {
+  template.hasResourceProperties("AWS::Lambda::Function", {
+    FunctionName: "stravaEventProcessorLambda",
+    Environment: Match.objectLike({
+      Variables: Match.objectLike({
+        WORDPRESS_API_BASE_URL:
+          "https://breakfastdinnertea.co.uk/wp-json/wp/v2",
+      }),
+    }),
+  });
+});

--- a/packages/bdt-cdk/test/strava-processor.test.ts
+++ b/packages/bdt-cdk/test/strava-processor.test.ts
@@ -7,7 +7,13 @@ import {
   beforeEach,
 } from "@jest/globals";
 
-import { handler } from "../lambda/strava-processor/index";
+import {
+  handler,
+  stravaToWordpress,
+  postExerciseToWordpress,
+  StravaActivity,
+  WordPressExercisePayload,
+} from "../lambda/strava-processor/index";
 import { SQSEvent, SQSRecord } from "aws-lambda";
 import {
   SSMClient,
@@ -30,8 +36,8 @@ jest.mock("axios", () => {
     get: mockGet,
   };
 });
-const mockedAxiosPost = axios.post as jest.Mock;
-const mockedAxiosGet = axios.get as jest.Mock;
+const mockedAxiosPost = axios.post as jest.Mock<any>;
+const mockedAxiosGet = axios.get as jest.Mock<any>;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -118,6 +124,120 @@ afterAll(() => {
   consoleLogSpy.mockRestore();
 });
 
+const exampleStravaActivity: StravaActivity = {
+  id: 17954327092,
+  name: "Evening Run",
+  description: "",
+  distance: 5040.2,
+  moving_time: 1956,
+  elapsed_time: 1956,
+  total_elevation_gain: 46,
+  type: "Run",
+  sport_type: "Run",
+  start_date: "2026-04-02T19:30:39Z",
+  start_date_local: "2026-04-02T20:30:39Z",
+  map: { summary_polyline: "encodedPolyline123" },
+};
+
+test("stravaToWordpress maps Strava fields to WordPress exercise payload", () => {
+  const result = stravaToWordpress(exampleStravaActivity);
+  expect(result.title).toBe("Evening Run");
+  expect(result.status).toBe("publish");
+  expect(result.meta.source_platform).toBe("strava");
+  expect(result.meta.source_id).toBe("17954327092");
+  expect(result.meta.activity_type).toBe("Run");
+  expect(result.meta.distance_meters).toBe(5040.2);
+  expect(result.meta.moving_time_seconds).toBe(1956);
+  expect(result.meta.elapsed_time_seconds).toBe(1956);
+  expect(result.meta.total_elevation_gain_meters).toBe(46);
+  expect(result.meta.start_date_local_iso).toBe("2026-04-02T20:30:39Z");
+  expect(result.meta.map_summary_polyline).toBe("encodedPolyline123");
+  expect(result.meta._raw_data_json).toBe(
+    JSON.stringify(exampleStravaActivity),
+  );
+});
+
+test("stravaToWordpress uses activity id as fallback title when name is absent", () => {
+  const result = stravaToWordpress({ ...exampleStravaActivity, name: "" });
+  expect(result.title).toBe("Strava Activity 17954327092");
+});
+
+test("stravaToWordpress uses type (not sport_type) as activity_type", () => {
+  const result = stravaToWordpress({
+    ...exampleStravaActivity,
+    type: "Ride",
+    sport_type: "MountainBikeRide",
+  });
+  expect(result.meta.activity_type).toBe("Ride");
+});
+
+test("stravaToWordpress uses empty string for map_summary_polyline when map is absent", () => {
+  const result = stravaToWordpress({
+    ...exampleStravaActivity,
+    map: undefined,
+  });
+  expect(result.meta.map_summary_polyline).toBe("");
+});
+
+describe("postExerciseToWordpress", () => {
+  const wpPayload: WordPressExercisePayload = {
+    title: "Evening Run",
+    content: "",
+    status: "publish",
+    meta: {
+      source_platform: "strava",
+      source_id: "17954327092",
+      activity_type: "Run",
+      distance_meters: 5040.2,
+      moving_time_seconds: 1956,
+      elapsed_time_seconds: 1956,
+      total_elevation_gain_meters: 46,
+      start_date_local_iso: "2026-04-02T20:30:39Z",
+      map_summary_polyline: "encodedPolyline123",
+      _raw_data_json: "{}",
+    },
+  };
+
+  beforeEach(() => {
+    process.env.BDT_AUTH_TOKEN = "test-wp-token";
+    process.env.WORDPRESS_API_BASE_URL = "https://example.com/wp-json/wp/v2";
+  });
+
+  afterEach(() => {
+    delete process.env.BDT_AUTH_TOKEN;
+    delete process.env.WORDPRESS_API_BASE_URL;
+  });
+
+  test("POSTs the exercise payload to WordPress with Bearer auth", async () => {
+    mockedAxiosPost.mockResolvedValueOnce({ data: { id: 999 }, status: 201 });
+    await postExerciseToWordpress(wpPayload);
+    expect(mockedAxiosPost).toHaveBeenCalledWith(
+      "https://example.com/wp-json/wp/v2/bdt_exercises",
+      wpPayload,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-wp-token",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  test("throws if BDT_AUTH_TOKEN env var is missing", async () => {
+    delete process.env.BDT_AUTH_TOKEN;
+    await expect(postExerciseToWordpress(wpPayload)).rejects.toThrow(
+      "Missing WordPress configuration.",
+    );
+  });
+
+  test("throws if WORDPRESS_API_BASE_URL env var is missing", async () => {
+    delete process.env.WORDPRESS_API_BASE_URL;
+    await expect(postExerciseToWordpress(wpPayload)).rejects.toThrow(
+      "Missing WordPress configuration.",
+    );
+  });
+});
+
 test("log the body of each received SQS message", async () => {
   const testBody1 = JSON.stringify({ activityId: 123, detail: "message one" });
   const testBody2 = JSON.stringify({ activityId: 456, detail: "message two" });
@@ -169,7 +289,7 @@ test("fetches activity details from Strava API", async () => {
     start_date_local: new Date().toISOString(),
   };
 
-  mockedAxiosGet.mockImplementation(async (url, _config) => {
+  mockedAxiosGet.mockImplementation(async (url: string, _config: unknown) => {
     console.log(`--- MOCK GET returning data for ${url} ---`);
     return Promise.resolve({
       data: dummyActivityData,
@@ -196,4 +316,52 @@ test("fetches activity details from Strava API", async () => {
   );
 
   expect(consoleLogSpy).toHaveBeenCalledWith("Processing complete.");
+});
+
+test("handler fetches Strava activity and posts it to WordPress", async () => {
+  process.env.BDT_AUTH_TOKEN = "test-wp-token";
+  process.env.WORDPRESS_API_BASE_URL = "https://example.com/wp-json/wp/v2";
+
+  mockedAxiosPost.mockResolvedValueOnce({
+    data: { access_token: "DUMMY_ACCESS_TOKEN_456" },
+    status: 200,
+  });
+  mockedAxiosPost.mockResolvedValueOnce({ data: { id: 999 }, status: 201 });
+
+  mockedAxiosGet.mockResolvedValueOnce({
+    data: exampleStravaActivity,
+    status: 200,
+  });
+
+  const sqsMessageBody = JSON.stringify({
+    object_type: "activity",
+    object_id: exampleStravaActivity.id,
+    aspect_type: "create",
+    owner_id: 12345,
+  });
+  await handler(createPartialSqsEventWithBodies([sqsMessageBody]) as SQSEvent);
+
+  expect(mockedAxiosGet).toHaveBeenCalledWith(
+    `https://www.strava.com/api/v3/activities/${exampleStravaActivity.id}`,
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: expect.stringContaining("Bearer"),
+      }),
+    }),
+  );
+  expect(mockedAxiosPost).toHaveBeenCalledWith(
+    "https://example.com/wp-json/wp/v2/bdt_exercises",
+    expect.objectContaining({
+      title: "Evening Run",
+      meta: expect.objectContaining({ source_platform: "strava" }),
+    }),
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer test-wp-token",
+      }),
+    }),
+  );
+
+  delete process.env.BDT_AUTH_TOKEN;
+  delete process.env.WORDPRESS_API_BASE_URL;
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@types/node':
         specifier: ^24.10.15
         version: 24.12.0
+      aws-cdk:
+        specifier: ^2.1118.0
+        version: 2.1118.0
       aws-cdk-lib:
         specifier: ^2.244.0
         version: 2.244.0(constructs@10.5.1)
@@ -3170,6 +3173,11 @@ packages:
       - table
       - yaml
       - mime-types
+
+  aws-cdk@2.1118.0:
+    resolution: {integrity: sha512-Tfd865GRewDTXIbTVtix/l+v8t3rZENvdHcQQZS2wXYVXfHzljULFXe9JKkgZUNDPB1zo9tSBUu8jjiHRm7nWg==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
 
   aws-sdk-client-mock-jest@4.1.0:
     resolution: {integrity: sha512-+g4a5Hp+MmPqqNnvwfLitByggrqf+xSbk1pm6fBYHNcon6+aQjL5iB+3YB6HuGPemY+/mUKN34iP62S14R61bA==}
@@ -9840,6 +9848,8 @@ snapshots:
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.1
       '@aws-cdk/cloud-assembly-schema': 52.2.0
       constructs: 10.5.1
+
+  aws-cdk@2.1118.0: {}
 
   aws-sdk-client-mock-jest@4.1.0(aws-sdk-client-mock@4.1.0):
     dependencies:


### PR DESCRIPTION
- Transform Strava webhook payloads into WordPress bdt_exercise posts via new stravaToWordpress() and postExerciseToWordpress() functions
- Add WORDPRESS_API_BASE_URL and BDT_AUTH_TOKEN (placeholder) env vars to the processor Lambda CDK definition
- Add aws-cdk CLI as a devDependency of bdt-cdk so it can be invoked via pnpm exec rather than a global install
- Fix hooks to use git rev-parse --show-toplevel so they work from any subdirectory
- Prefer .ts over .js in Jest module resolution to avoid stale compiled Lambda artifacts shadowing TypeScript sources