### PR TITLE
feat(activities): render SVG route preview alongside activity entries (#1104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist
 # Local Netlify folder
 .netlify
 yarn-error.log
+
+# Git worktrees
+.worktrees

--- a/packages/activity-fetcher/src/getActivities.test.ts
+++ b/packages/activity-fetcher/src/getActivities.test.ts
@@ -64,7 +64,8 @@ test("requests all activity fields in GraphQL query", async () => {
         body.query.includes("activityType") &&
         body.query.includes("distanceMeters") &&
         body.query.includes("movingTimeSeconds") &&
-        body.query.includes("startDateLocalIso"),
+        body.query.includes("startDateLocalIso") &&
+        body.query.includes("mapSummaryPolyline"),
     )
     .reply(200, makeResponse([]));
 

--- a/packages/activity-fetcher/src/getActivities.ts
+++ b/packages/activity-fetcher/src/getActivities.ts
@@ -15,6 +15,7 @@ const getActivities = async (
     "distanceMeters",
     "movingTimeSeconds",
     "startDateLocalIso",
+    "mapSummaryPolyline",
   ];
 
   const { data: activities, meta } = await getData<Activity>(

--- a/packages/bdt-components/src/logo/logo.module.css
+++ b/packages/bdt-components/src/logo/logo.module.css
@@ -15,5 +15,5 @@
 }
 
 .logo .highlighted {
-  color: #b81007;
+  color: var(--bdt-red, #b81007);
 }

--- a/packages/bdt-components/src/media/RoutePreview.test.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { RoutePreview } from "./RoutePreview";
+
+// Google example: [[38.5,-120.2],[40.7,-120.95],[43.252,-126.453]]
+const EXAMPLE_POLYLINE = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+
+describe("RoutePreview", () => {
+  it("renders an SVG element", () => {
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders a polyline element inside the SVG", () => {
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    expect(container.querySelector("polyline")).not.toBeNull();
+  });
+
+  it("sets viewBox to '0 0 100 100'", () => {
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("viewBox")).toBe(
+      "0 0 100 100",
+    );
+  });
+
+  it("preserves aspect ratio via preserveAspectRatio", () => {
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    expect(
+      container.querySelector("svg")?.getAttribute("preserveAspectRatio"),
+    ).toBe("xMidYMid meet");
+  });
+
+  it("uses BDT_RED as the stroke colour", () => {
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    expect(container.querySelector("polyline")?.getAttribute("stroke")).toBe(
+      "#b81007",
+    );
+  });
+
+  it("polyline points attribute is non-empty", () => {
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    const points = container.querySelector("polyline")?.getAttribute("points");
+    expect(points).toBeTruthy();
+    expect(points?.length).toBeGreaterThan(0);
+  });
+
+  it("normalises coordinates to fit within the viewBox with padding", () => {
+    // Decoded points: [[38.5,-120.2],[40.7,-120.95],[43.252,-126.453]]
+    // Bottom-right corner maps to 95,95; top-left to 5,5 (5px padding on 100px viewBox)
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    const points = container.querySelector("polyline")?.getAttribute("points");
+    expect(points).toBe("95.00,95.00 84.21,53.33 5.00,5.00");
+  });
+});

--- a/packages/bdt-components/src/media/RoutePreview.test.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.test.tsx
@@ -56,13 +56,17 @@ describe("RoutePreview", () => {
     expect(points?.length).toBeGreaterThan(0);
   });
 
-  it("normalises coordinates to fit within the viewBox with padding", () => {
+  it("passes the correct encoded polyline data through to the SVG points", () => {
     // Decoded points: [[38.5,-120.2],[40.7,-120.95],[43.252,-126.453]]
-    // Bottom-right corner maps to 95,95; top-left to 5,5 (5px padding on 100px viewBox)
+    // Route is lat-dominant → fills full height, y spans 5→95
     const { container } = render(
       <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
     );
-    const points = container.querySelector("polyline")?.getAttribute("points");
-    expect(points).toBe("95.00,95.00 84.21,53.33 5.00,5.00");
+    const raw = container.querySelector("polyline")?.getAttribute("points");
+    const coords = raw!.split(" ").map((p) => p.split(",").map(Number));
+    expect(coords).toHaveLength(3);
+    // southernmost point is at bottom (y≈95), northernmost at top (y≈5)
+    expect(coords[0][1]).toBeCloseTo(95, 0);
+    expect(coords[2][1]).toBeCloseTo(5, 0);
   });
 });

--- a/packages/bdt-components/src/media/RoutePreview.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { decodePolyline, LatLng } from "./decodePolyline";
+import { BDT_RED } from "./colours";
+
+interface RoutePreviewProps {
+  encodedPolyline: string;
+}
+
+const VIEWBOX_SIZE = 100;
+const PADDING = 5;
+
+const normalise = (points: LatLng[]): string => {
+  const lats = points.map(([lat]) => lat);
+  const lngs = points.map(([, lng]) => lng);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const latRange = maxLat - minLat || 1;
+  const lngRange = maxLng - minLng || 1;
+  const scale = VIEWBOX_SIZE - PADDING * 2;
+
+  return points
+    .map(([lat, lng]) => {
+      const x = PADDING + ((lng - minLng) / lngRange) * scale;
+      const y = PADDING + ((maxLat - lat) / latRange) * scale;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+};
+
+export const RoutePreview = ({
+  encodedPolyline,
+}: RoutePreviewProps): JSX.Element => {
+  const points = decodePolyline(encodedPolyline);
+  const pointsAttr = normalise(points);
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEWBOX_SIZE} ${VIEWBOX_SIZE}`}
+      preserveAspectRatio="xMidYMid meet"
+      width="154"
+      height="154"
+      aria-hidden="true"
+    >
+      <polyline
+        points={pointsAttr}
+        fill="none"
+        stroke={BDT_RED}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/packages/bdt-components/src/media/RoutePreview.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { decodePolyline, LatLng } from "./decodePolyline";
+import { decodePolyline } from "./decodePolyline";
+import { normalisePolyline } from "./normalisePolyline";
 import { BDT_RED } from "./colours";
 
 interface RoutePreviewProps {
@@ -7,33 +8,12 @@ interface RoutePreviewProps {
 }
 
 const VIEWBOX_SIZE = 100;
-const PADDING = 5;
-
-const normalise = (points: LatLng[]): string => {
-  const lats = points.map(([lat]) => lat);
-  const lngs = points.map(([, lng]) => lng);
-  const minLat = Math.min(...lats);
-  const maxLat = Math.max(...lats);
-  const minLng = Math.min(...lngs);
-  const maxLng = Math.max(...lngs);
-  const latRange = maxLat - minLat || 1;
-  const lngRange = maxLng - minLng || 1;
-  const scale = VIEWBOX_SIZE - PADDING * 2;
-
-  return points
-    .map(([lat, lng]) => {
-      const x = PADDING + ((lng - minLng) / lngRange) * scale;
-      const y = PADDING + ((maxLat - lat) / latRange) * scale;
-      return `${x.toFixed(2)},${y.toFixed(2)}`;
-    })
-    .join(" ");
-};
 
 export const RoutePreview = ({
   encodedPolyline,
 }: RoutePreviewProps): JSX.Element => {
   const points = decodePolyline(encodedPolyline);
-  const pointsAttr = normalise(points);
+  const pointsAttr = normalisePolyline(points);
 
   return (
     <svg

--- a/packages/bdt-components/src/media/activity-entry.test.tsx
+++ b/packages/bdt-components/src/media/activity-entry.test.tsx
@@ -70,3 +70,47 @@ describe("ActivityEntry time display", () => {
     expect(container).not.toHaveTextContent("Time");
   });
 });
+
+describe("ActivityEntry route preview", () => {
+  it("renders an SVG when mapSummaryPolyline is provided", () => {
+    const { container } = render(
+      <ActivityEntry
+        activity={{
+          ...baseActivity,
+          mapSummaryPolyline: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+        }}
+      />,
+    );
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("passes the encoded polyline to the SVG route preview", () => {
+    const { container } = render(
+      <ActivityEntry
+        activity={{
+          ...baseActivity,
+          mapSummaryPolyline: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+        }}
+      />,
+    );
+    const polylineEl = container.querySelector("svg polyline");
+    expect(polylineEl).not.toBeNull();
+    // The points attribute must contain multiple coordinate pairs derived from
+    // the decoded polyline — an empty or wrong string would produce "" or a
+    // single degenerate point instead of space-separated pairs.
+    const points = polylineEl?.getAttribute("points") ?? "";
+    expect(points.split(" ").length).toBeGreaterThan(1);
+  });
+
+  it("renders no SVG when mapSummaryPolyline is absent", () => {
+    const { container } = render(<ActivityEntry activity={baseActivity} />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders no SVG when mapSummaryPolyline is an empty string", () => {
+    const { container } = render(
+      <ActivityEntry activity={{ ...baseActivity, mapSummaryPolyline: "" }} />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/packages/bdt-components/src/media/activity-entry.tsx
+++ b/packages/bdt-components/src/media/activity-entry.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Activity } from "@tdee/types/src/bdt";
+import { RoutePreview } from "./RoutePreview";
 
 interface ActivityProps {
   activity: Activity;
@@ -53,7 +54,11 @@ export const ActivityEntry = ({ activity }: ActivityProps): JSX.Element => {
             </dl>
           </div>
         </div>
-        <div style={{ maxWidth: "154px" }} />
+        <div style={{ maxWidth: "154px" }}>
+          {activity.mapSummaryPolyline ? (
+            <RoutePreview encodedPolyline={activity.mapSummaryPolyline} />
+          ) : null}
+        </div>
       </div>
     </article>
   );

--- a/packages/bdt-components/src/media/colours.ts
+++ b/packages/bdt-components/src/media/colours.ts
@@ -1,0 +1,3 @@
+export const BDT_RED = "#b81007";
+export const BDT_BLUE = "#345693";
+export const BDT_YELLOW = "#dfcc4c";

--- a/packages/bdt-components/src/media/decodePolyline.test.ts
+++ b/packages/bdt-components/src/media/decodePolyline.test.ts
@@ -1,0 +1,51 @@
+import { decodePolyline } from "./decodePolyline";
+
+describe("decodePolyline", () => {
+  it("decodes an empty string to an empty array", () => {
+    expect(decodePolyline("")).toEqual([]);
+  });
+
+  it("decodes a single point", () => {
+    // Encoded form of [[-17.96584, 0.0]] per Google algorithm
+    const result = decodePolyline("n}slB?");
+    expect(result).toHaveLength(1);
+    expect(result[0][0]).toBeCloseTo(-17.96584, 4);
+    expect(result[0][1]).toBeCloseTo(0.0, 4);
+  });
+
+  it("decodes two points (Google example)", () => {
+    // Google's documented example: [[38.5,-120.2],[40.7,-120.95]]
+    // Encoded: "_p~iF~ps|U_ulLnnqC"
+    const result = decodePolyline("_p~iF~ps|U_ulLnnqC");
+    expect(result).toHaveLength(2);
+    expect(result[0][0]).toBeCloseTo(38.5, 4);
+    expect(result[0][1]).toBeCloseTo(-120.2, 4);
+    expect(result[1][0]).toBeCloseTo(40.7, 4);
+    expect(result[1][1]).toBeCloseTo(-120.95, 4);
+  });
+
+  it("decodes three points (Google example)", () => {
+    // Google's full example: [[38.5,-120.2],[40.7,-120.95],[43.252,-126.453]]
+    // Encoded: "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+    const result = decodePolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+    expect(result).toHaveLength(3);
+    expect(result[2][0]).toBeCloseTo(43.252, 4);
+    expect(result[2][1]).toBeCloseTo(-126.453, 4);
+  });
+
+  it("returns lat as first element and lng as second", () => {
+    const result = decodePolyline("_p~iF~ps|U");
+    const [lat, lng] = result[0];
+    expect(lat).toBeCloseTo(38.5, 4);
+    expect(lng).toBeCloseTo(-120.2, 4);
+  });
+
+  it("decodes a point with zero-valued continuation chunks in the lng", () => {
+    // lng=0.16384 encodes to '___@' which has continuation bytes with value exactly 0x20
+    // (low 5 bits all zero but continuation bit set) — exercises the >= 0x20 boundary
+    const result = decodePolyline("?___@");
+    expect(result).toHaveLength(1);
+    expect(result[0][0]).toBeCloseTo(0.0, 4);
+    expect(result[0][1]).toBeCloseTo(0.16384, 4);
+  });
+});

--- a/packages/bdt-components/src/media/decodePolyline.ts
+++ b/packages/bdt-components/src/media/decodePolyline.ts
@@ -1,0 +1,34 @@
+// Algorithm: https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+export type LatLng = [number, number];
+
+export const decodePolyline = (encoded: string): LatLng[] => {
+  const points: LatLng[] = [];
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+
+  while (index < encoded.length) {
+    let shift = 0;
+    let result = 0;
+    let byte: number;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    lat += result & 1 ? ~(result >> 1) : result >> 1;
+
+    shift = 0;
+    result = 0;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    lng += result & 1 ? ~(result >> 1) : result >> 1;
+
+    points.push([lat / 1e5, lng / 1e5]);
+  }
+
+  return points;
+};

--- a/packages/bdt-components/src/media/normalisePolyline.test.ts
+++ b/packages/bdt-components/src/media/normalisePolyline.test.ts
@@ -1,0 +1,42 @@
+import { normalisePolyline } from "./normalisePolyline";
+import { LatLng } from "./decodePolyline";
+
+describe("normalisePolyline", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalisePolyline([])).toBe("");
+  });
+
+  it("centres a single point at (50.00,50.00)", () => {
+    expect(normalisePolyline([[51.5, -0.1]])).toBe("50.00,50.00");
+  });
+
+  it("centres a vertical route (constant longitude) horizontally", () => {
+    // Two points at the same lng → all x coords should be at the centre (50)
+    const points: LatLng[] = [
+      [0, 0],
+      [1, 0],
+    ];
+    expect(normalisePolyline(points)).toBe("50.00,95.00 50.00,5.00");
+  });
+
+  it("centres a horizontal route (constant latitude) vertically", () => {
+    // midLat = 0, cos(0) = 1 → no lng correction needed
+    // lngRange = 2 > latRange = 1 → lat axis is centred
+    const points: LatLng[] = [
+      [-0.5, 0],
+      [0.5, 2],
+    ];
+    expect(normalisePolyline(points)).toBe("5.00,72.50 95.00,27.50");
+  });
+
+  it("applies cosine correction: at 60°N midlat, 2° longitude equals 1° latitude", () => {
+    // cos(60°) = 0.5 exactly, so 2° lng × 0.5 = 1° lat equivalent
+    // latRange = 2°, lngRangeCorrected = 2° × 0.5 = 1° → lat dominates
+    // scale = 90/2 = 45; lngExtent = 45 → xOffset = 22.5 (centred)
+    const points: LatLng[] = [
+      [59, 0],
+      [61, 2],
+    ];
+    expect(normalisePolyline(points)).toBe("27.50,95.00 72.50,5.00");
+  });
+});

--- a/packages/bdt-components/src/media/normalisePolyline.ts
+++ b/packages/bdt-components/src/media/normalisePolyline.ts
@@ -1,0 +1,33 @@
+import { LatLng } from "./decodePolyline";
+
+const VIEWBOX_SIZE = 100;
+const PADDING = 5;
+
+export const normalisePolyline = (points: LatLng[]): string => {
+  if (points.length === 0) return "";
+
+  const lats = points.map(([lat]) => lat);
+  const lngs = points.map(([, lng]) => lng);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const latRange = maxLat - minLat;
+  const lngRange = maxLng - minLng;
+  const midLat = (minLat + maxLat) / 2;
+  const cosLat = Math.cos((midLat * Math.PI) / 180);
+  const lngRangeCorrected = lngRange * cosLat;
+  const available = VIEWBOX_SIZE - PADDING * 2;
+  const maxRange = Math.max(latRange, lngRangeCorrected);
+  const scale = maxRange > 0 ? available / maxRange : 1;
+  const xOffset = (available - lngRangeCorrected * scale) / 2;
+  const yOffset = (available - latRange * scale) / 2;
+
+  return points
+    .map(([lat, lng]) => {
+      const x = PADDING + xOffset + (lng - minLng) * cosLat * scale;
+      const y = PADDING + yOffset + (maxLat - lat) * scale;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+};

--- a/packages/bdt-components/src/nav/nav.module.css
+++ b/packages/bdt-components/src/nav/nav.module.css
@@ -1,6 +1,6 @@
 .mainMenu a {
-  color: #345693;
-  text-decoration-color: #b81007;
+  color: var(--bdt-blue, #345693);
+  text-decoration-color: var(--bdt-red, #b81007);
   text-underline-offset: var(--s-4);
 }
 

--- a/packages/bdt-components/src/visualisations/calendar.tsx
+++ b/packages/bdt-components/src/visualisations/calendar.tsx
@@ -5,8 +5,9 @@ import {
   Calendar as NivoCalendar,
   Datum,
 } from "@nivo/calendar";
+import { BDT_RED, BDT_YELLOW } from "../media/colours";
 
-const gradients = ["#dfcc4c", "#daa525", "#d27d01", "#c75100", "#b81007"];
+const gradients = [BDT_YELLOW, "#daa525", "#d27d01", "#c75100", BDT_RED];
 
 const Calendar = ({
   data,

--- a/packages/bdt-components/src/visualisations/weight-graph.tsx
+++ b/packages/bdt-components/src/visualisations/weight-graph.tsx
@@ -13,6 +13,7 @@ import {
 import { format } from "date-fns";
 import { DayPicker, DateRange } from "react-day-picker";
 import "react-day-picker/dist/style.css";
+import { BDT_RED, BDT_BLUE } from "../media/colours";
 
 const WeightGraph = ({
   weighins,
@@ -207,7 +208,7 @@ const WeightGraph = ({
               <Line
                 type="monotone"
                 dataKey="weight"
-                stroke="#b81007"
+                stroke={BDT_RED}
                 activeDot={{ r: 8 }}
                 strokeWidth={2}
                 isAnimationActive={responsive}
@@ -219,7 +220,7 @@ const WeightGraph = ({
               <Line
                 type="monotone"
                 dataKey="weightTrend"
-                stroke="#345693"
+                stroke={BDT_BLUE}
                 activeDot={{ r: 8 }}
                 strokeWidth={2}
                 strokeDasharray="12 4"

--- a/packages/types/src/bdt.ts
+++ b/packages/types/src/bdt.ts
@@ -69,4 +69,5 @@ export interface Activity {
   distanceMeters?: number;
   movingTimeSeconds?: number;
   startDateLocalIso: string;
+  mapSummaryPolyline?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `mapSummaryPolyline?: string` to the `Activity` type and requests it from the GraphQL fetcher
- Implements a pure-TypeScript Google encoded polyline decoder (`decodePolyline`) and a `RoutePreview` SVG component that normalises coordinates to a 100×100 viewBox and renders the route shape in `BDT_RED`
- Wires `RoutePreview` into `ActivityEntry` — renders in the existing 154px side slot when a polyline is present, nothing when absent (gym sessions, etc.)
- Extracts `BDT_RED`, `BDT_BLUE`, and `BDT_YELLOW` into a shared `colours.ts` and updates all hardcoded hex literals across the component library

## Test Plan
- [x] Activities with a polyline show a recognisable route shape in the activity feed
- [x] Activities without a polyline (gym sessions) show nothing in the side slot
- [x] 198 tests passing across all packages (`pnpm test && pnpm --filter @tdee/bdt-components test && pnpm --filter @tdee/bdt-cdk test`)
- [x] TypeScript compiles clean (`pnpm compile`)

Closes #1104