### PR TITLE
feat(activities): smooth route previews with Chaikin's algorithm

### DIFF
--- a/packages/bdt-components/src/media/RoutePreview.test.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.test.tsx
@@ -71,17 +71,6 @@ describe("RoutePreview", () => {
     expect(coords[23][1]).toBeCloseTo(5, 0);
   });
 
-  it("applies Chaikin smoothing after RDP to produce more points than the simplified route", () => {
-    // EXAMPLE_POLYLINE decodes to 3 points; RDP keeps all 3; Chaikin(3) produces 24.
-    // Verifies Chaikin is wired in (output > RDP-only count of 3).
-    const { container } = render(
-      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
-    );
-    const raw = container.querySelector("polyline")?.getAttribute("points");
-    const coords = raw!.split(" ");
-    expect(coords.length).toBeGreaterThan(3);
-  });
-
   it("simplifies collinear intermediate points before rendering", () => {
     // Encodes [[0,0],[0,0.5],[0,1]] — three points all at lat=0, i.e. collinear
     // RDP (epsilon=0.0001°) removes [0,0.5] because its perpendicular distance

--- a/packages/bdt-components/src/media/RoutePreview.test.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.test.tsx
@@ -58,16 +58,28 @@ describe("RoutePreview", () => {
 
   it("passes the correct encoded polyline data through to the SVG points", () => {
     // Decoded points: [[38.5,-120.2],[40.7,-120.95],[43.252,-126.453]]
-    // Route is lat-dominant → fills full height, y spans 5→95
+    // RDP keeps all 3 (non-collinear). Chaikin(3 iters): 3 → 6 → 12 → 24 points.
+    // Endpoints are preserved by Chaikin, so first point is still southernmost (y≈95)
+    // and last point (index 23) is still northernmost (y≈5).
     const { container } = render(
       <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
     );
     const raw = container.querySelector("polyline")?.getAttribute("points");
     const coords = raw!.split(" ").map((p) => p.split(",").map(Number));
-    expect(coords).toHaveLength(3);
-    // southernmost point is at bottom (y≈95), northernmost at top (y≈5)
+    expect(coords).toHaveLength(24);
     expect(coords[0][1]).toBeCloseTo(95, 0);
-    expect(coords[2][1]).toBeCloseTo(5, 0);
+    expect(coords[23][1]).toBeCloseTo(5, 0);
+  });
+
+  it("applies Chaikin smoothing after RDP to produce more points than the simplified route", () => {
+    // EXAMPLE_POLYLINE decodes to 3 points; RDP keeps all 3; Chaikin(3) produces 24.
+    // Verifies Chaikin is wired in (output > RDP-only count of 3).
+    const { container } = render(
+      <RoutePreview encodedPolyline={EXAMPLE_POLYLINE} />,
+    );
+    const raw = container.querySelector("polyline")?.getAttribute("points");
+    const coords = raw!.split(" ");
+    expect(coords.length).toBeGreaterThan(3);
   });
 
   it("simplifies collinear intermediate points before rendering", () => {

--- a/packages/bdt-components/src/media/RoutePreview.tsx
+++ b/packages/bdt-components/src/media/RoutePreview.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { chaikinSmooth } from "./chaikin";
 import { decodePolyline } from "./decodePolyline";
 import { normalisePolyline } from "./normalisePolyline";
 import { ramerDouglasPeucker } from "./ramerDouglasPeucker";
@@ -10,13 +11,15 @@ interface RoutePreviewProps {
 
 const VIEWBOX_SIZE = 100;
 const EPSILON = 0.0001;
+const CHAIKIN_ITERATIONS = 3;
 
 export const RoutePreview = ({
   encodedPolyline,
 }: RoutePreviewProps): JSX.Element => {
   const decoded = decodePolyline(encodedPolyline);
-  const points = ramerDouglasPeucker(decoded, EPSILON);
-  const pointsAttr = normalisePolyline(points);
+  const simplified = ramerDouglasPeucker(decoded, EPSILON);
+  const smoothed = chaikinSmooth(simplified, CHAIKIN_ITERATIONS);
+  const pointsAttr = normalisePolyline(smoothed);
 
   return (
     <svg

--- a/packages/bdt-components/src/media/chaikin.test.ts
+++ b/packages/bdt-components/src/media/chaikin.test.ts
@@ -1,0 +1,79 @@
+// Algorithm: https://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html
+import { chaikinSmooth } from "./chaikin";
+import { LatLng } from "./decodePolyline";
+
+describe("chaikinSmooth", () => {
+  it("returns empty array for empty input", () => {
+    expect(chaikinSmooth([], 3)).toEqual([]);
+  });
+
+  it("returns a single point unchanged", () => {
+    expect(chaikinSmooth([[51.5, -0.1]], 3)).toEqual([[51.5, -0.1]]);
+  });
+
+  it("returns two points unchanged", () => {
+    const points: LatLng[] = [
+      [0, 0],
+      [1, 1],
+    ];
+    expect(chaikinSmooth(points, 3)).toEqual([
+      [0, 0],
+      [1, 1],
+    ]);
+  });
+
+  it("returns input unchanged when iterations is 0", () => {
+    const points: LatLng[] = [
+      [0, 0],
+      [2, 2],
+      [4, 0],
+    ];
+    expect(chaikinSmooth(points, 0)).toEqual([
+      [0, 0],
+      [2, 2],
+      [4, 0],
+    ]);
+  });
+
+  it("produces correct coordinates for 1 iteration on a 3-point route", () => {
+    // Input: [0,0] → [2,2] → [4,0]
+    // Edge [0,0]→[2,2]: Q=0.75·[0,0]+0.25·[2,2]=[0.5,0.5], R=0.25·[0,0]+0.75·[2,2]=[1.5,1.5]
+    // Edge [2,2]→[4,0]: Q=0.75·[2,2]+0.25·[4,0]=[2.5,1.5], R=0.25·[2,2]+0.75·[4,0]=[3.5,0.5]
+    // Endpoints preserved: [0,0] at start, [4,0] at end
+    const points: LatLng[] = [
+      [0, 0],
+      [2, 2],
+      [4, 0],
+    ];
+    expect(chaikinSmooth(points, 1)).toEqual([
+      [0, 0],
+      [0.5, 0.5],
+      [1.5, 1.5],
+      [2.5, 1.5],
+      [3.5, 0.5],
+      [4, 0],
+    ]);
+  });
+
+  it("preserves the first and last points after multiple iterations", () => {
+    const points: LatLng[] = [
+      [10, 20],
+      [30, 40],
+      [50, 60],
+    ];
+    const result = chaikinSmooth(points, 5);
+    expect(result[0]).toEqual([10, 20]);
+    expect(result[result.length - 1]).toEqual([50, 60]);
+  });
+
+  it("doubles the point count each iteration (n≥3)", () => {
+    const points: LatLng[] = [
+      [0, 0],
+      [1, 1],
+      [2, 0],
+    ];
+    expect(chaikinSmooth(points, 1)).toHaveLength(6); // 3 → 6
+    expect(chaikinSmooth(points, 2)).toHaveLength(12); // 6 → 12
+    expect(chaikinSmooth(points, 3)).toHaveLength(24); // 12 → 24
+  });
+});

--- a/packages/bdt-components/src/media/chaikin.test.ts
+++ b/packages/bdt-components/src/media/chaikin.test.ts
@@ -65,7 +65,7 @@ describe("chaikinSmooth", () => {
     expect(result[result.length - 1]).toEqual([50, 60]);
   });
 
-  it("doubles the point count each iteration (n≥3)", () => {
+  it("doubles the point count per iteration for a 3-point input", () => {
     const points: LatLng[] = [
       [0, 0],
       [1, 1],

--- a/packages/bdt-components/src/media/chaikin.test.ts
+++ b/packages/bdt-components/src/media/chaikin.test.ts
@@ -1,4 +1,3 @@
-// Algorithm: https://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html
 import { chaikinSmooth } from "./chaikin";
 import { LatLng } from "./decodePolyline";
 

--- a/packages/bdt-components/src/media/chaikin.ts
+++ b/packages/bdt-components/src/media/chaikin.ts
@@ -1,0 +1,22 @@
+// Algorithm: https://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html
+import { LatLng } from "./decodePolyline";
+
+export const chaikinSmooth = (
+  points: LatLng[],
+  iterations: number,
+): LatLng[] => {
+  if (points.length < 3) return points;
+  let result = points;
+  for (let iter = 0; iter < iterations; iter++) {
+    const next: LatLng[] = [result[0]];
+    for (let i = 0; i < result.length - 1; i++) {
+      const [lat0, lng0] = result[i];
+      const [lat1, lng1] = result[i + 1];
+      next.push([0.75 * lat0 + 0.25 * lat1, 0.75 * lng0 + 0.25 * lng1]);
+      next.push([0.25 * lat0 + 0.75 * lat1, 0.25 * lng0 + 0.75 * lng1]);
+    }
+    next.push(result[result.length - 1]);
+    result = next;
+  }
+  return result;
+};


### PR DESCRIPTION
## Summary

- Adds `chaikin.ts` implementing Chaikin's curve-subdivision algorithm with endpoint preservation
- Inserts it into the `RoutePreview` pipeline after RDP simplification: decode → RDP → Chaikin (3 iterations) → normalise
- RDP removes redundant GPS noise; Chaikin rounds the remaining corners for a visually smoother thumbnail

## Test plan

- [ ] Unit tests for `chaikin.ts` pass — empty/1pt/2pt edge cases, exact coordinate output for 1 iteration, endpoint preservation, point-count growth
- [ ] `RoutePreview` tests pass — updated length assertion (3→24 coordinate pairs for the Google example polyline), collinear test still produces 2 pairs (RDP output of 2 bypasses Chaikin)
- [ ] Full test suite passes — 117 tests, 0 regressions
- [ ] Compare preview build vs merged main visually — routes should look smoother without changing overall shape

Closes #1106