### PR TITLE
feat(activities): add Strava profile and per-activity links

### DIFF
--- a/packages/activity-fetcher/src/getActivities.ts
+++ b/packages/activity-fetcher/src/getActivities.ts
@@ -10,6 +10,7 @@ const getActivities = async (
 ): Promise<{ activities: Activity[]; meta: PageInfo }> => {
   const nodeName = "exercises";
   const fields = [
+    "sourceId",
     "title",
     "activityType",
     "distanceMeters",

--- a/packages/bdt-astro/src/pages/activities.astro
+++ b/packages/bdt-astro/src/pages/activities.astro
@@ -10,6 +10,11 @@ const recent = [...global.activities].reverse().slice(0, 10);
 <BaseLayout title="Activities">
   <div class="stack listing">
     <h1>Activities</h1>
+    <p>
+      These are activities I've completed recently, as logged in <a
+        href="https://www.strava.com/athletes/2764169">Strava</a
+      >.
+    </p>
     {recent.map((activity) => <ActivityEntry activity={activity} />)}
     <p>
       See my <a href="/activities/page/1">full activities stream</a> for the complete list.

--- a/packages/bdt-components/src/media/activity-entry.test.tsx
+++ b/packages/bdt-components/src/media/activity-entry.test.tsx
@@ -71,6 +71,34 @@ describe("ActivityEntry time display", () => {
   });
 });
 
+describe("ActivityEntry Strava link", () => {
+  it("renders a link to the Strava activity page when sourceId is provided", () => {
+    const { container } = render(
+      <ActivityEntry activity={{ ...baseActivity, sourceId: "18456924412" }} />,
+    );
+    const link = container.querySelector(
+      'a[href="https://www.strava.com/activities/18456924412"]',
+    );
+    expect(link).not.toBeNull();
+  });
+
+  it("link text reads 'View on Strava'", () => {
+    const { getByRole } = render(
+      <ActivityEntry activity={{ ...baseActivity, sourceId: "18456924412" }} />,
+    );
+    const link = getByRole("link", { name: "View on Strava" });
+    expect(link).toBeTruthy();
+  });
+
+  it("does not render a Strava link when sourceId is absent", () => {
+    const { container } = render(<ActivityEntry activity={baseActivity} />);
+    const link = container.querySelector(
+      'a[href^="https://www.strava.com/activities/"]',
+    );
+    expect(link).toBeNull();
+  });
+});
+
 describe("ActivityEntry route preview", () => {
   it("renders an SVG when mapSummaryPolyline is provided", () => {
     const { container } = render(

--- a/packages/bdt-components/src/media/activity-entry.tsx
+++ b/packages/bdt-components/src/media/activity-entry.tsx
@@ -52,6 +52,13 @@ export const ActivityEntry = ({ activity }: ActivityProps): JSX.Element => {
                 </>
               ) : null}
             </dl>
+            {activity.sourceId && (
+              <a
+                href={`https://www.strava.com/activities/${activity.sourceId}`}
+              >
+                View on Strava
+              </a>
+            )}
           </div>
         </div>
         <div style={{ maxWidth: "154px" }}>

--- a/packages/bdt-customisations/lib/register-exercises.php
+++ b/packages/bdt-customisations/lib/register-exercises.php
@@ -144,6 +144,14 @@ add_action('graphql_register_types', function () {
         },
     ]);
 
+    register_graphql_field($type_name, 'sourceId', [
+        'type' => 'String',
+        'description' => __('The unique identifier from the source platform (e.g. Strava activity ID)'),
+        'resolve' => function ($post) {
+            return get_post_meta($post->ID, 'source_id', true);
+        },
+    ]);
+
     add_filter('graphql_PostObjectsConnectionOrderbyEnum_values', function ($values) {
         $values['START_DATE_LOCAL_ISO'] = [
             'value' => 'start_date_local_iso',

--- a/packages/types/src/bdt.ts
+++ b/packages/types/src/bdt.ts
@@ -64,6 +64,7 @@ export interface Weighin {
 export type CalculatedWeighin = Weighin & { weightTrend: number };
 
 export interface Activity {
+  sourceId?: string;
   title: string;
   activityType: string;
   distanceMeters?: number;


### PR DESCRIPTION
## Summary

- Registers `sourceId` as a WPGraphQL field on exercises, reading from the `source_id` post meta (the Strava activity ID)
- Adds `sourceId?: string` to the `Activity` TypeScript type and fetches it in the GraphQL query
- Renders a conditional "View on Strava" link on each `ActivityEntry` (hidden when `sourceId` is absent)
- Adds a Strava profile attribution sentence to the activities landing page, mirroring the Letterboxd pattern on the films page

## Test Plan

- [ ] Deploy `bdt-customisations` plugin to WordPress — verify `{ exercises { edges { node { sourceId } } } }` returns numeric Strava IDs (e.g. `"18456924412"`)
- [ ] Check activities page shows "as logged in Strava" with working profile link
- [ ] Check individual activity cards show "View on Strava" linking to `https://www.strava.com/activities/<id>`
- [ ] All 48 tests pass (`pnpm test`)