### PR TITLE
feat(blog): add blog listing, post view, and taxonomy navigation

### DIFF
--- a/packages/bdt-astro/src/pages/[year]/[month]/[slug].astro
+++ b/packages/bdt-astro/src/pages/[year]/[month]/[slug].astro
@@ -1,0 +1,43 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import getAllPosts from "@wp-fetcher/getAllPosts";
+import type { WPPost } from "@tdee/types/src/bdt";
+
+export async function getStaticPaths() {
+  global.posts = global.posts ?? (await getAllPosts());
+
+  return (global.posts as WPPost[]).map((post) => {
+    const d = new Date(post.date);
+    const year = String(d.getFullYear());
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    return {
+      params: { year, month, slug: post.slug },
+      props: { post },
+    };
+  });
+}
+
+const { post } = Astro.props as { post: WPPost };
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+---
+
+<BaseLayout title={post.title}>
+  <style slot="head_after" lang="scss" is:global>
+    @use "../../../style/content.scss";
+  </style>
+
+  <article>
+    <h1>{post.title}</h1>
+    <time datetime={post.date}>{formatDate(post.date)}</time>
+    <div class="content">
+      <Fragment set:html={post.content} />
+    </div>
+  </article>
+</BaseLayout>

--- a/packages/bdt-astro/src/pages/blog.astro
+++ b/packages/bdt-astro/src/pages/blog.astro
@@ -1,0 +1,27 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { PostEntry } from "@components/media/post-entry";
+import Pagination from "@components/pagination/pagination.tsx";
+import getAllPosts from "@wp-fetcher/getAllPosts";
+
+global.posts = global.posts ?? (await getAllPosts());
+const data = global.posts.slice(0, 10);
+---
+
+<BaseLayout title="Blog">
+  <div class="stack listing">
+    <h1>Blog</h1>
+
+    {data.map((post) => <PostEntry post={post} />)}
+
+    <Pagination
+      tag="a"
+      pageNumber={1}
+      urlRoot="/blog/page"
+      pageInfo={{
+        hasNextPage: true,
+        hasPreviousPage: false,
+      }}
+    />
+  </div>
+</BaseLayout>

--- a/packages/bdt-astro/src/pages/blog/[year]/[month]/[slug].astro
+++ b/packages/bdt-astro/src/pages/blog/[year]/[month]/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "../../../layouts/BaseLayout.astro";
+import BaseLayout from "../../../../layouts/BaseLayout.astro";
 import getAllPosts from "@wp-fetcher/getAllPosts";
 import type { WPPost } from "@tdee/types/src/bdt";
 
@@ -30,12 +30,26 @@ function formatDate(dateStr: string): string {
 
 <BaseLayout title={post.title}>
   <style slot="head_after" lang="scss" is:global>
-    @use "../../../style/content.scss";
+    @use "../../../../style/content.scss";
   </style>
 
   <article>
     <h1>{post.title}</h1>
     <time datetime={post.date}>{formatDate(post.date)}</time>
+    {post.categories.nodes.length > 0 && (
+      <ul class="categories">
+        {post.categories.nodes.map((cat) => (
+          <li><a href={`/blog/category/${cat.slug}/`}>{cat.name}</a></li>
+        ))}
+      </ul>
+    )}
+    {post.tags.nodes.length > 0 && (
+      <ul class="tags">
+        {post.tags.nodes.map((tag) => (
+          <li><a href={`/blog/tag/${tag.slug}/`}>{tag.name}</a></li>
+        ))}
+      </ul>
+    )}
     <div class="content">
       <Fragment set:html={post.content} />
     </div>

--- a/packages/bdt-astro/src/pages/blog/page/[page].astro
+++ b/packages/bdt-astro/src/pages/blog/page/[page].astro
@@ -1,0 +1,31 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { PostEntry } from "@components/media/post-entry";
+import Pagination from "@components/pagination/pagination.tsx";
+import getAllPosts from "@wp-fetcher/getAllPosts";
+
+export async function getStaticPaths({ paginate }) {
+  global.posts = global.posts ?? (await getAllPosts());
+  return paginate(global.posts, { pageSize: 10 });
+}
+
+const { page } = Astro.props;
+---
+
+<BaseLayout title={`Blog: Page ${page.currentPage}`}>
+  <div class="stack listing">
+    <h1>Blog: Page {page.currentPage}</h1>
+
+    {page.data.map((post) => <PostEntry post={post} />)}
+
+    <Pagination
+      tag="a"
+      pageNumber={parseInt(page.currentPage, 10)}
+      urlRoot="/blog/page"
+      pageInfo={{
+        hasNextPage: page.url.next ? true : false,
+        hasPreviousPage: page.url.prev ? true : false,
+      }}
+    />
+  </div>
+</BaseLayout>

--- a/packages/bdt-components/src/media/post-entry.test.tsx
+++ b/packages/bdt-components/src/media/post-entry.test.tsx
@@ -10,13 +10,23 @@ const mockPost: WPPost = {
   date: "2016-02-15T10:00:00",
   excerpt: "<p>A post about the Jinteki.net plugin.</p>",
   content: "<p>Full content here.</p>",
+  tags: {
+    nodes: [
+      { name: "Netrunner", slug: "netrunner" },
+      { name: "Plugin", slug: "plugin" },
+    ],
+  },
+  categories: { nodes: [{ name: "Tech", slug: "tech" }] },
 };
 
 test("renders the post title as a link", () => {
   render(<PostEntry post={mockPost} />);
   const link = screen.getByRole("link", { name: mockPost.title });
   expect(link).toBeInTheDocument();
-  expect(link).toHaveAttribute("href", "/2016/02/jinteki-net-plugin-jankteki/");
+  expect(link).toHaveAttribute(
+    "href",
+    "/blog/2016/02/jinteki-net-plugin-jankteki/",
+  );
 });
 
 test("renders the post date", () => {
@@ -29,4 +39,42 @@ test("renders the excerpt as HTML", () => {
   expect(
     screen.getByText("A post about the Jinteki.net plugin."),
   ).toBeInTheDocument();
+});
+
+test("renders category links", () => {
+  render(<PostEntry post={mockPost} />);
+  const link = screen.getByRole("link", { name: "Tech" });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute("href", "/blog/category/tech/");
+});
+
+test("renders tag links", () => {
+  render(<PostEntry post={mockPost} />);
+  const netrunnerLink = screen.getByRole("link", { name: "Netrunner" });
+  expect(netrunnerLink).toBeInTheDocument();
+  expect(netrunnerLink).toHaveAttribute("href", "/blog/tag/netrunner/");
+  const pluginLink = screen.getByRole("link", { name: "Plugin" });
+  expect(pluginLink).toHaveAttribute("href", "/blog/tag/plugin/");
+});
+
+test("renders no category links when post has no categories", () => {
+  render(<PostEntry post={{ ...mockPost, categories: { nodes: [] } }} />);
+  expect(screen.queryByRole("link", { name: "Tech" })).not.toBeInTheDocument();
+});
+
+test("renders no tag links when post has no tags", () => {
+  render(<PostEntry post={{ ...mockPost, tags: { nodes: [] } }} />);
+  expect(
+    screen.queryByRole("link", { name: "Netrunner" }),
+  ).not.toBeInTheDocument();
+});
+
+test("renders category links even when post has no tags", () => {
+  render(<PostEntry post={{ ...mockPost, tags: { nodes: [] } }} />);
+  expect(screen.getByRole("link", { name: "Tech" })).toBeInTheDocument();
+});
+
+test("renders tag links even when post has no categories", () => {
+  render(<PostEntry post={{ ...mockPost, categories: { nodes: [] } }} />);
+  expect(screen.getByRole("link", { name: "Netrunner" })).toBeInTheDocument();
 });

--- a/packages/bdt-components/src/media/post-entry.test.tsx
+++ b/packages/bdt-components/src/media/post-entry.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { PostEntry } from "./post-entry";
+import type { WPPost } from "@tdee/types/src/bdt";
+
+const mockPost: WPPost = {
+  id: "cG9zdDoxMjM=",
+  title: "Jinteki.net Plugin: Jankteki",
+  slug: "jinteki-net-plugin-jankteki",
+  date: "2016-02-15T10:00:00",
+  excerpt: "<p>A post about the Jinteki.net plugin.</p>",
+  content: "<p>Full content here.</p>",
+};
+
+test("renders the post title as a link", () => {
+  render(<PostEntry post={mockPost} />);
+  const link = screen.getByRole("link", { name: mockPost.title });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute("href", "/2016/02/jinteki-net-plugin-jankteki/");
+});
+
+test("renders the post date", () => {
+  render(<PostEntry post={mockPost} />);
+  expect(screen.getByText(/15 February 2016/i)).toBeInTheDocument();
+});
+
+test("renders the excerpt as HTML", () => {
+  render(<PostEntry post={mockPost} />);
+  expect(
+    screen.getByText("A post about the Jinteki.net plugin."),
+  ).toBeInTheDocument();
+});

--- a/packages/bdt-components/src/media/post-entry.tsx
+++ b/packages/bdt-components/src/media/post-entry.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import type { WPPost } from "@tdee/types/src/bdt";
+
+interface PostEntryProps {
+  post: WPPost;
+}
+
+function postPath(post: WPPost): string {
+  const d = new Date(post.date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `/${year}/${month}/${post.slug}/`;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export const PostEntry = ({ post }: PostEntryProps): JSX.Element => {
+  return (
+    <article className="stack compressed">
+      <header>
+        <h2>
+          <a href={postPath(post)}>{post.title}</a>
+        </h2>
+        <time dateTime={post.date}>{formatDate(post.date)}</time>
+      </header>
+      <div dangerouslySetInnerHTML={{ __html: post.excerpt }} />
+    </article>
+  );
+};

--- a/packages/bdt-components/src/media/post-entry.tsx
+++ b/packages/bdt-components/src/media/post-entry.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { WPPost } from "@tdee/types/src/bdt";
+import type { WPPost, WPTaxonomyTerm } from "@tdee/types/src/bdt";
 
 interface PostEntryProps {
   post: WPPost;
@@ -9,7 +9,7 @@ function postPath(post: WPPost): string {
   const d = new Date(post.date);
   const year = d.getFullYear();
   const month = String(d.getMonth() + 1).padStart(2, "0");
-  return `/${year}/${month}/${post.slug}/`;
+  return `/blog/${year}/${month}/${post.slug}/`;
 }
 
 function formatDate(dateStr: string): string {
@@ -30,6 +30,24 @@ export const PostEntry = ({ post }: PostEntryProps): JSX.Element => {
         <time dateTime={post.date}>{formatDate(post.date)}</time>
       </header>
       <div dangerouslySetInnerHTML={{ __html: post.excerpt }} />
+      {post.categories.nodes.length > 0 && (
+        <ul className="categories">
+          {post.categories.nodes.map((cat: WPTaxonomyTerm) => (
+            <li key={cat.slug}>
+              <a href={`/blog/category/${cat.slug}/`}>{cat.name}</a>
+            </li>
+          ))}
+        </ul>
+      )}
+      {post.tags.nodes.length > 0 && (
+        <ul className="tags">
+          {post.tags.nodes.map((tag: WPTaxonomyTerm) => (
+            <li key={tag.slug}>
+              <a href={`/blog/tag/${tag.slug}/`}>{tag.name}</a>
+            </li>
+          ))}
+        </ul>
+      )}
     </article>
   );
 };

--- a/packages/types/src/bdt.ts
+++ b/packages/types/src/bdt.ts
@@ -41,6 +41,15 @@ export interface WPPage {
   slug: string;
 }
 
+export interface WPPost {
+  id: string;
+  title: string;
+  slug: string;
+  date: string; // ISO string e.g. "2016-02-15T10:00:00"
+  excerpt: string;
+  content: string;
+}
+
 export interface Film {
   watchedDate: string;
   filmTitle: string;

--- a/packages/types/src/bdt.ts
+++ b/packages/types/src/bdt.ts
@@ -15,6 +15,11 @@ export interface PageInfo {
   hasPreviousPage: boolean;
 }
 
+export interface WPTaxonomyTerm {
+  name: string;
+  slug: string;
+}
+
 export interface Podcast {
   listenDate: string;
   podcastTitle: string;
@@ -48,6 +53,8 @@ export interface WPPost {
   date: string; // ISO string e.g. "2016-02-15T10:00:00"
   excerpt: string;
   content: string;
+  tags: { nodes: WPTaxonomyTerm[] };
+  categories: { nodes: WPTaxonomyTerm[] };
 }
 
 export interface Film {

--- a/packages/wp-fetcher/src/getAllPosts.test.ts
+++ b/packages/wp-fetcher/src/getAllPosts.test.ts
@@ -1,0 +1,57 @@
+import getAllPosts from "./getAllPosts";
+import * as nock from "nock";
+
+beforeAll(() => nock.disableNetConnect());
+afterAll(() => nock.enableNetConnect());
+afterEach(() => nock.cleanAll());
+
+const makePost = (suffix: string) => ({
+  id: `id-${suffix}`,
+  title: `Post ${suffix}`,
+  slug: `post-${suffix}`,
+  date: "2016-02-15T10:00:00",
+  excerpt: "<p>excerpt</p>",
+  content: "<p>content</p>",
+});
+
+const makePage = (
+  nodes: object[],
+  endCursor: string,
+  hasNextPage: boolean,
+) => ({
+  data: {
+    posts: {
+      nodes,
+      pageInfo: {
+        endCursor,
+        startCursor: "start",
+        hasNextPage,
+        hasPreviousPage: false,
+      },
+    },
+  },
+});
+
+test("collects all posts across multiple pages", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql")
+    .reply(200, makePage([makePost("one"), makePost("two")], "cursor1", true))
+    .post("/graphql")
+    .reply(200, makePage([makePost("three")], "cursor2", false));
+
+  const posts = await getAllPosts();
+
+  expect(posts).toHaveLength(3);
+  expect(posts[0].slug).toBe("post-one");
+  expect(posts[2].slug).toBe("post-three");
+});
+
+test("returns empty array when there are no posts", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql")
+    .reply(200, makePage([], "cursor1", false));
+
+  const posts = await getAllPosts();
+
+  expect(posts).toHaveLength(0);
+});

--- a/packages/wp-fetcher/src/getAllPosts.test.ts
+++ b/packages/wp-fetcher/src/getAllPosts.test.ts
@@ -46,6 +46,19 @@ test("collects all posts across multiple pages", async () => {
   expect(posts[2].slug).toBe("post-three");
 });
 
+test("passes endCursor from each page to the next request", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql")
+    .reply(200, makePage([makePost("one")], "cursor-from-page-1", true))
+    .post("/graphql", (body) => body.query.includes("cursor-from-page-1"))
+    .reply(200, makePage([makePost("two")], "cursor-from-page-2", false));
+
+  const posts = await getAllPosts();
+
+  expect(posts).toHaveLength(2);
+  expect(nock.isDone()).toBe(true);
+});
+
 test("returns empty array when there are no posts", async () => {
   nock("https://breakfastdinnertea.co.uk")
     .post("/graphql")

--- a/packages/wp-fetcher/src/getAllPosts.ts
+++ b/packages/wp-fetcher/src/getAllPosts.ts
@@ -1,0 +1,19 @@
+import { WPPost } from "@tdee/types/src/bdt";
+import getPosts from "./getPosts";
+
+const getAllPosts = async (): Promise<WPPost[]> => {
+  const allPosts: WPPost[] = [];
+  let cursor: string | undefined;
+  let hasMore = true;
+
+  while (hasMore) {
+    const { posts, meta } = await getPosts(cursor, "100");
+    allPosts.push(...posts);
+    hasMore = meta.hasNextPage;
+    cursor = meta.endCursor;
+  }
+
+  return allPosts;
+};
+
+export default getAllPosts;

--- a/packages/wp-fetcher/src/getPosts.test.ts
+++ b/packages/wp-fetcher/src/getPosts.test.ts
@@ -46,6 +46,54 @@ test("returns posts and meta with expected fields", async () => {
   expect(meta.endCursor).toBe("cursor123");
 });
 
+test("includes all required fields in the GraphQL query", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql", (body) =>
+      ["id", "title", "slug", "date", "excerpt", "content"].every((f) =>
+        body.query.includes(f),
+      ),
+    )
+    .reply(200, {
+      data: {
+        posts: {
+          nodes: [],
+          pageInfo: {
+            endCursor: "cursor1",
+            startCursor: "cursor0",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+  await getPosts();
+
+  expect(nock.isDone()).toBe(true);
+});
+
+test("includes ordering clause in the GraphQL query", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql", (body) => body.query.includes("DATE"))
+    .reply(200, {
+      data: {
+        posts: {
+          nodes: [],
+          pageInfo: {
+            endCursor: "cursor1",
+            startCursor: "cursor0",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+  await getPosts();
+
+  expect(nock.isDone()).toBe(true);
+});
+
 test("passes 'after' cursor to GraphQL query", async () => {
   nock("https://breakfastdinnertea.co.uk")
     .post("/graphql", (body) => body.query.includes("cursor123"))

--- a/packages/wp-fetcher/src/getPosts.test.ts
+++ b/packages/wp-fetcher/src/getPosts.test.ts
@@ -12,6 +12,8 @@ const mockPost = {
   date: "2016-02-15T10:00:00",
   excerpt: "<p>A short excerpt.</p>",
   content: "<p>The full post content.</p>",
+  tags: { nodes: [{ name: "Netrunner", slug: "netrunner" }] },
+  categories: { nodes: [{ name: "Tech", slug: "tech" }] },
 };
 
 test("returns posts and meta with expected fields", async () => {
@@ -41,6 +43,8 @@ test("returns posts and meta with expected fields", async () => {
     date: mockPost.date,
     excerpt: mockPost.excerpt,
     content: mockPost.content,
+    tags: mockPost.tags,
+    categories: mockPost.categories,
   });
   expect(meta.hasNextPage).toBe(false);
   expect(meta.endCursor).toBe("cursor123");
@@ -49,9 +53,43 @@ test("returns posts and meta with expected fields", async () => {
 test("includes all required fields in the GraphQL query", async () => {
   nock("https://breakfastdinnertea.co.uk")
     .post("/graphql", (body) =>
-      ["id", "title", "slug", "date", "excerpt", "content"].every((f) =>
-        body.query.includes(f),
-      ),
+      [
+        "id",
+        "title",
+        "slug",
+        "date",
+        "excerpt",
+        "content",
+        "tags",
+        "categories",
+      ].every((f) => body.query.includes(f)),
+    )
+    .reply(200, {
+      data: {
+        posts: {
+          nodes: [],
+          pageInfo: {
+            endCursor: "cursor1",
+            startCursor: "cursor0",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+  await getPosts();
+
+  expect(nock.isDone()).toBe(true);
+});
+
+test("includes taxonomy sub-fields in the GraphQL query", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql", (body) =>
+      [
+        "tags { nodes { name slug } }",
+        "categories { nodes { name slug } }",
+      ].every((f) => body.query.includes(f)),
     )
     .reply(200, {
       data: {

--- a/packages/wp-fetcher/src/getPosts.test.ts
+++ b/packages/wp-fetcher/src/getPosts.test.ts
@@ -1,0 +1,70 @@
+import getPosts from "./getPosts";
+import * as nock from "nock";
+
+beforeAll(() => nock.disableNetConnect());
+afterAll(() => nock.enableNetConnect());
+afterEach(() => nock.cleanAll());
+
+const mockPost = {
+  id: "cG9zdDoxMjM=",
+  title: "Jinteki.net Plugin: Jankteki",
+  slug: "jinteki-net-plugin-jankteki",
+  date: "2016-02-15T10:00:00",
+  excerpt: "<p>A short excerpt.</p>",
+  content: "<p>The full post content.</p>",
+};
+
+test("returns posts and meta with expected fields", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql")
+    .reply(200, {
+      data: {
+        posts: {
+          nodes: [mockPost],
+          pageInfo: {
+            endCursor: "cursor123",
+            startCursor: "cursor000",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+  const { posts, meta } = await getPosts();
+
+  expect(posts).toHaveLength(1);
+  expect(posts[0]).toMatchObject({
+    id: mockPost.id,
+    title: mockPost.title,
+    slug: mockPost.slug,
+    date: mockPost.date,
+    excerpt: mockPost.excerpt,
+    content: mockPost.content,
+  });
+  expect(meta.hasNextPage).toBe(false);
+  expect(meta.endCursor).toBe("cursor123");
+});
+
+test("passes 'after' cursor to GraphQL query", async () => {
+  nock("https://breakfastdinnertea.co.uk")
+    .post("/graphql", (body) => body.query.includes("cursor123"))
+    .reply(200, {
+      data: {
+        posts: {
+          nodes: [],
+          pageInfo: {
+            endCursor: "cursor456",
+            startCursor: "cursor123",
+            hasNextPage: false,
+            hasPreviousPage: true,
+          },
+        },
+      },
+    });
+
+  const { meta } = await getPosts("cursor123");
+
+  expect(meta.hasPreviousPage).toBe(true);
+  expect(nock.isDone()).toBe(true);
+});

--- a/packages/wp-fetcher/src/getPosts.ts
+++ b/packages/wp-fetcher/src/getPosts.ts
@@ -2,7 +2,16 @@ import getData from "@tdee/graphql-fetcher/src/getData";
 import { PageInfo, WPPost } from "@tdee/types/src/bdt";
 
 const whereClause = "{orderby: {field: DATE, order: DESC}}";
-const fields = ["id", "title", "slug", "date", "excerpt", "content"];
+const fields = [
+  "id",
+  "title",
+  "slug",
+  "date",
+  "excerpt",
+  "content",
+  "tags { nodes { name slug } }",
+  "categories { nodes { name slug } }",
+];
 
 const getPosts = async (
   after?: string,

--- a/packages/wp-fetcher/src/getPosts.ts
+++ b/packages/wp-fetcher/src/getPosts.ts
@@ -1,0 +1,22 @@
+import getData from "@tdee/graphql-fetcher/src/getData";
+import { PageInfo, WPPost } from "@tdee/types/src/bdt";
+
+const whereClause = "{orderby: {field: DATE, order: DESC}}";
+const fields = ["id", "title", "slug", "date", "excerpt", "content"];
+
+const getPosts = async (
+  after?: string,
+  first?: string,
+): Promise<{ posts: WPPost[]; meta: PageInfo }> => {
+  const { data: posts, meta } = await getData<WPPost>(
+    "posts",
+    fields,
+    after,
+    whereClause,
+    first ?? "10",
+  );
+
+  return { posts, meta };
+};
+
+export default getPosts;

--- a/packages/wp-fetcher/tsconfig.json
+++ b/packages/wp-fetcher/tsconfig.json
@@ -10,7 +10,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@bdt-types/*": ["../types/src/*"]
+      "@bdt-types/*": ["../types/src/*"],
+      "@tdee/*": ["../../*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `WPPost` type and `getPosts`/`getAllPosts` fetchers backed by WPGraphQL
- Adds `/blog/` listing and paginated `/blog/page/[n]/` pages using a new `PostEntry` component
- Adds post view at `/blog/[year]/[month]/[slug]/`
- Extends `WPPost` with `tags` and `categories` (`WPTaxonomyTerm`) and surfaces them as navigable links — categories at `/blog/category/[slug]/`, tags at `/blog/tag/[slug]/`

## Test plan

- [x] All tests pass (`pnpm test`)
- [x] Visit `/blog/` — posts listed with category and tag links
- [x] Visit a post — title, date, categories, tags, and content rendered
- [x] Category and tag links are correct (e.g. `/blog/category/tech/`, `/blog/tag/netrunner/`)
- [x] **Note:** `/blog/category/[slug]/` and `/blog/tag/[slug]/` pages are not yet implemented (tracked in #1114)